### PR TITLE
Convoy Lance Tagging Fix

### DIFF
--- a/VIPAdvanced/lances/lancedef_vehicle_d10_OpForConvoy.json
+++ b/VIPAdvanced/lances/lancedef_vehicle_d10_OpForConvoy.json
@@ -15,7 +15,8 @@
          "lance_type_battle",
          "lance_type_assault",
          "lance_type_dynamic",
-         "lance_type_vehicle"
+         "lance_type_vehicle",
+         "lance_type_OpForConvoy"
       ],
       "tagSetSourceFile": "Tags/LanceTags"
    },

--- a/VIPAdvanced/lances/lancedef_vehicle_d1_OpForConvoy.json
+++ b/VIPAdvanced/lances/lancedef_vehicle_d1_OpForConvoy.json
@@ -15,7 +15,8 @@
          "lance_type_battle",
          "lance_type_light",
          "lance_type_dynamic",
-         "lance_type_vehicle"
+         "lance_type_vehicle",
+         "lance_type_OpForConvoy"
       ],
       "tagSetSourceFile": "Tags/LanceTags"
    },

--- a/VIPAdvanced/lances/lancedef_vehicle_d2_OpForConvoy.json
+++ b/VIPAdvanced/lances/lancedef_vehicle_d2_OpForConvoy.json
@@ -15,7 +15,8 @@
          "lance_type_battle",
          "lance_type_light",
          "lance_type_dynamic",
-         "lance_type_vehicle"
+         "lance_type_vehicle",
+         "lance_type_OpForConvoy"
       ],
       "tagSetSourceFile": "Tags/LanceTags"
    },

--- a/VIPAdvanced/lances/lancedef_vehicle_d3_OpForConvoy.json
+++ b/VIPAdvanced/lances/lancedef_vehicle_d3_OpForConvoy.json
@@ -15,7 +15,8 @@
          "lance_type_battle",
          "lance_type_light",
          "lance_type_dynamic",
-         "lance_type_vehicle"
+         "lance_type_vehicle",
+         "lance_type_OpForConvoy"
       ],
       "tagSetSourceFile": "Tags/LanceTags"
    },

--- a/VIPAdvanced/lances/lancedef_vehicle_d4_OpForConvoy.json
+++ b/VIPAdvanced/lances/lancedef_vehicle_d4_OpForConvoy.json
@@ -15,7 +15,8 @@
             "lance_type_battle",
             "lance_type_light",
             "lance_type_vehicle",
-            "lance_type_dynamic"
+            "lance_type_dynamic",
+            "lance_type_OpForConvoy"
         ],
         "tagSetSourceFile": "Tags/LanceTags"
     },

--- a/VIPAdvanced/lances/lancedef_vehicle_d5_OpForConvoy.json
+++ b/VIPAdvanced/lances/lancedef_vehicle_d5_OpForConvoy.json
@@ -15,7 +15,8 @@
          "lance_type_battle",
          "lance_type_medium",
          "lance_type_dynamic",
-         "lance_type_vehicle"
+         "lance_type_vehicle",
+         "lance_type_OpForConvoy"
       ],
       "tagSetSourceFile": "Tags/LanceTags"
    },

--- a/VIPAdvanced/lances/lancedef_vehicle_d6_OpForConvoy.json
+++ b/VIPAdvanced/lances/lancedef_vehicle_d6_OpForConvoy.json
@@ -15,7 +15,8 @@
          "lance_type_battle",
          "lance_type_medium",
          "lance_type_dynamic",
-         "lance_type_vehicle"
+         "lance_type_vehicle",
+         "lance_type_OpForConvoy"
       ],
       "tagSetSourceFile": "Tags/LanceTags"
    },

--- a/VIPAdvanced/lances/lancedef_vehicle_d7_OpForConvoy.json
+++ b/VIPAdvanced/lances/lancedef_vehicle_d7_OpForConvoy.json
@@ -15,7 +15,8 @@
          "lance_type_battle",
          "lance_type_heavy",
          "lance_type_dynamic",
-         "lance_type_vehicle"
+         "lance_type_vehicle",
+         "lance_type_OpForConvoy"
       ],
       "tagSetSourceFile": "Tags/LanceTags"
    },

--- a/VIPAdvanced/lances/lancedef_vehicle_d8_OpForConvoy.json
+++ b/VIPAdvanced/lances/lancedef_vehicle_d8_OpForConvoy.json
@@ -15,7 +15,8 @@
          "lance_type_battle",
          "lance_type_heavy",
          "lance_type_dynamic",
-         "lance_type_vehicle"
+         "lance_type_vehicle",
+         "lance_type_OpForConvoy"
       ],
       "tagSetSourceFile": "Tags/LanceTags"
    },

--- a/VIPAdvanced/lances/lancedef_vehicle_d9_OpForConvoy.json
+++ b/VIPAdvanced/lances/lancedef_vehicle_d9_OpForConvoy.json
@@ -15,7 +15,8 @@
          "lance_type_battle",
          "lance_type_assault",
          "lance_type_dynamic",
-         "lance_type_vehicle"
+         "lance_type_vehicle",
+         "lance_type_OpForConvoy"
       ],
       "tagSetSourceFile": "Tags/LanceTags"
    },


### PR DESCRIPTION
Missing tag was causing wrong lances to be picked for enemies in Ambush contracts.