### PR TITLE
Quick and dirty AMS rebalance

### DIFF
--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM10_0-STOCK.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM10_0-STOCK.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": -0.88,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM10",
     "Description" : {
         "Cost" : 150000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM10_0-STOCK.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM10_0-STOCK.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM10",
     "Description" : {
         "Cost" : 150000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM10_1-Delta.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM10_1-Delta.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 2,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM10",
     "Description" : {
         "Cost" : 160000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM10_1-Delta.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM10_1-Delta.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 2,
-    "AMSHitChance": -0.88,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM10",
     "Description" : {
         "Cost" : 160000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM10_1-LongFire.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM10_1-LongFire.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": -0.88,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM10",
     "Description" : {
         "Cost" : 160000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM10_1-LongFire.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM10_1-LongFire.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM10",
     "Description" : {
         "Cost" : 160000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM10_1-Telos.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM10_1-Telos.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM10",
     "Description" : {
         "Cost" : 180000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM10_1-Telos.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM10_1-Telos.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": -0.88,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM10",
     "Description" : {
         "Cost" : 180000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM10_2-Delta.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM10_2-Delta.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": -0.88,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM10",
     "Description" : {
         "Cost" : 200000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM10_2-Delta.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM10_2-Delta.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM10",
     "Description" : {
         "Cost" : 200000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM10_2-LongFire.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM10_2-LongFire.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": -0.88,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM10",
     "Description" : {
         "Cost" : 170000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM10_2-LongFire.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM10_2-LongFire.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM10",
     "Description" : {
         "Cost" : 170000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM10_2-Telos.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM10_2-Telos.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": -0.88,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM10",
     "Description" : {
         "Cost" : 200000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM10_2-Telos.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM10_2-Telos.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM10",
     "Description" : {
         "Cost" : 200000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM10_2-Zeus.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM10_2-Zeus.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 2,
-    "AMSHitChance": -0.88,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM10",
     "Description" : {
         "Cost" : 170000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM10_2-Zeus.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM10_2-Zeus.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 2,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM10",
     "Description" : {
         "Cost" : 170000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM10_3-Zeus.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM10_3-Zeus.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": -0.88,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM10",
     "Description" : {
         "Cost" : 200000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM10_3-Zeus.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM10_3-Zeus.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM10",
     "Description" : {
         "Cost" : 200000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM15_0-STOCK.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM15_0-STOCK.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM15",
     "Description" : {
         "Cost" : 220000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM15_0-STOCK.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM15_0-STOCK.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": -0.88,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM15",
     "Description" : {
         "Cost" : 220000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM15_1-Delta.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM15_1-Delta.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM15",
     "Description" : {
         "Cost" : 250000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM15_1-Delta.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM15_1-Delta.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": -0.88,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM15",
     "Description" : {
         "Cost" : 250000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM15_1-LongFire.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM15_1-LongFire.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM15",
     "Description" : {
         "Cost" : 230000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM15_1-LongFire.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM15_1-LongFire.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": -0.88,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM15",
     "Description" : {
         "Cost" : 230000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM15_1-Telos.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM15_1-Telos.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": -0.88,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM15",
     "Description" : {
         "Cost" : 260000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM15_1-Telos.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM15_1-Telos.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM15",
     "Description" : {
         "Cost" : 260000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM15_2-Delta.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM15_2-Delta.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": -0.88,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM15",
     "Description" : {
         "Cost" : 300000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM15_2-Delta.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM15_2-Delta.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM15",
     "Description" : {
         "Cost" : 300000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM15_2-LongFire.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM15_2-LongFire.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM15",
     "Description" : {
         "Cost" : 240000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM15_2-LongFire.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM15_2-LongFire.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": -0.88,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM15",
     "Description" : {
         "Cost" : 240000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM15_2-Telos.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM15_2-Telos.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM15",
     "Description" : {
         "Cost" : 310000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM15_2-Telos.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM15_2-Telos.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": -0.88,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM15",
     "Description" : {
         "Cost" : 310000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM15_2-Zeus.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM15_2-Zeus.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 2,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM15",
     "Description" : {
         "Cost" : 260000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM15_2-Zeus.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM15_2-Zeus.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 2,
-    "AMSHitChance": -0.88,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM15",
     "Description" : {
         "Cost" : 260000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM15_3-Zeus.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM15_3-Zeus.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": -0.88,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM15",
     "Description" : {
         "Cost" : 290000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM15_3-Zeus.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM15_3-Zeus.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM15",
     "Description" : {
         "Cost" : 290000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM20_0-STOCK.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM20_0-STOCK.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM20",
     "Description" : {
         "Cost" : 290000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM20_0-STOCK.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM20_0-STOCK.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": -0.88,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM20",
     "Description" : {
         "Cost" : 290000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM20_1-Delta.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM20_1-Delta.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 2,
-    "AMSHitChance": -0.88,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM20",
     "Description" : {
         "Cost" : 320000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM20_1-Delta.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM20_1-Delta.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 2,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM20",
     "Description" : {
         "Cost" : 320000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM20_1-LongFire.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM20_1-LongFire.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": -0.88,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM20",
     "Description" : {
         "Cost" : 300000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM20_1-LongFire.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM20_1-LongFire.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM20",
     "Description" : {
         "Cost" : 300000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM20_1-Telos.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM20_1-Telos.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": -0.88,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM20",
     "Description" : {
         "Cost" : 340000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM20_1-Telos.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM20_1-Telos.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM20",
     "Description" : {
         "Cost" : 340000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM20_2-Delta.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM20_2-Delta.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": -0.88,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM20",
     "Description" : {
         "Cost" : 350000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM20_2-Delta.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM20_2-Delta.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM20",
     "Description" : {
         "Cost" : 350000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM20_2-LongFire.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM20_2-LongFire.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": -0.88,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM20",
     "Description" : {
         "Cost" : 310000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM20_2-LongFire.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM20_2-LongFire.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM20",
     "Description" : {
         "Cost" : 310000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM20_2-Telos.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM20_2-Telos.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": -0.88,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM20",
     "Description" : {
         "Cost" : 400000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM20_2-Telos.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM20_2-Telos.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM20",
     "Description" : {
         "Cost" : 400000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM20_2-Zeus.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM20_2-Zeus.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 2,
-    "AMSHitChance": -0.88,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM20",
     "Description" : {
         "Cost" : 330000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM20_2-Zeus.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM20_2-Zeus.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 2,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM20",
     "Description" : {
         "Cost" : 330000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM20_3-Zeus.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM20_3-Zeus.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM20",
     "Description" : {
         "Cost" : 370000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM20_3-Zeus.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM20_3-Zeus.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": -0.88,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM20",
     "Description" : {
         "Cost" : 370000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM5_0-STOCK.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM5_0-STOCK.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM5",
     "Description" : {
         "Cost" : 80000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM5_0-STOCK.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM5_0-STOCK.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": -0.88,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM5",
     "Description" : {
         "Cost" : 80000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM5_1-Delta.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM5_1-Delta.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 2,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM5",
     "Description" : {
         "Cost" : 80000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM5_1-Delta.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM5_1-Delta.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 2,
-    "AMSHitChance": -0.88,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM5",
     "Description" : {
         "Cost" : 80000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM5_1-LongFire.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM5_1-LongFire.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM5",
     "Description" : {
         "Cost" : 90000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM5_1-LongFire.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM5_1-LongFire.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": -0.88,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM5",
     "Description" : {
         "Cost" : 90000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM5_1-Telos.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM5_1-Telos.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM5",
     "Description" : {
         "Cost" : 90000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM5_1-Telos.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM5_1-Telos.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": -0.88,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM5",
     "Description" : {
         "Cost" : 90000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM5_2-Delta.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM5_2-Delta.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM5",
     "Description" : {
         "Cost" : 100000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM5_2-Delta.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM5_2-Delta.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": -0.88,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM5",
     "Description" : {
         "Cost" : 100000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM5_2-LongFire.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM5_2-LongFire.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": -0.88,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM5",
     "Description" : {
         "Cost" : 100000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM5_2-LongFire.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM5_2-LongFire.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM5",
     "Description" : {
         "Cost" : 100000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM5_2-Telos.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM5_2-Telos.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": -0.88,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM5",
     "Description" : {
         "Cost" : 110000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM5_2-Telos.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM5_2-Telos.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 1,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM5",
     "Description" : {
         "Cost" : 110000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM5_2-Zeus.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM5_2-Zeus.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 2,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM5",
     "Description" : {
         "Cost" : 100000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM5_2-Zeus.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM5_2-Zeus.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 2,
-    "AMSHitChance": -0.88,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM5",
     "Description" : {
         "Cost" : 100000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM5_3-Zeus.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM5_3-Zeus.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": -0.88,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM5",
     "Description" : {
         "Cost" : 120000,

--- a/BD Weapon Rebalance/weapons/Weapon_LRM_LRM5_3-Zeus.json
+++ b/BD Weapon Rebalance/weapons/Weapon_LRM_LRM5_3-Zeus.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM5",
     "Description" : {
         "Cost" : 120000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM2_0-STOCK.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM2_0-STOCK.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM2",
     "Description" : {
         "Cost" : 20000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM2_0-STOCK.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM2_0-STOCK.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": -0.97,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM2",
     "Description" : {
         "Cost" : 20000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM2_1-Holly.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM2_1-Holly.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": -0.97,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM2",
     "Description" : {
         "Cost" : 30000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM2_1-Holly.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM2_1-Holly.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM2",
     "Description" : {
         "Cost" : 30000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM2_1-Irian.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM2_1-Irian.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": -0.97,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM2",
     "Description" : {
         "Cost" : 30000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM2_1-Irian.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM2_1-Irian.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM2",
     "Description" : {
         "Cost" : 30000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM2_2-Holly.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM2_2-Holly.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": -0.97,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM2",
     "Description" : {
         "Cost" : 40000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM2_2-Holly.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM2_2-Holly.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM2",
     "Description" : {
         "Cost" : 40000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM2_2-Irian.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM2_2-Irian.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": -0.97,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM2",
     "Description" : {
         "Cost" : 40000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM2_2-Irian.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM2_2-Irian.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM2",
     "Description" : {
         "Cost" : 40000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM2_2-Valiant.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM2_2-Valiant.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 4,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM2",
     "Description" : {
         "Cost" : 30000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM2_2-Valiant.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM2_2-Valiant.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 4,
-    "AMSHitChance": -0.97,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM2",
     "Description" : {
         "Cost" : 30000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM2_3-Valiant.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM2_3-Valiant.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 5,
-    "AMSHitChance": -0.97,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM2",
     "Description" : {
         "Cost" : 40000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM2_3-Valiant.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM2_3-Valiant.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 5,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM2",
     "Description" : {
         "Cost" : 40000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM4_0-STOCK.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM4_0-STOCK.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM4",
     "Description" : {
         "Cost" : 60000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM4_0-STOCK.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM4_0-STOCK.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": -0.97,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM4",
     "Description" : {
         "Cost" : 60000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM4_1-Holly.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM4_1-Holly.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": -0.97,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM4",
     "Description" : {
         "Cost" : 70000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM4_1-Holly.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM4_1-Holly.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM4",
     "Description" : {
         "Cost" : 70000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM4_1-Irian.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM4_1-Irian.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM4",
     "Description" : {
         "Cost" : 60000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM4_1-Irian.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM4_1-Irian.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": -0.97,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM4",
     "Description" : {
         "Cost" : 60000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM4_2-Holly.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM4_2-Holly.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": -0.97,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM4",
     "Description" : {
         "Cost" : 90000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM4_2-Holly.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM4_2-Holly.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM4",
     "Description" : {
         "Cost" : 90000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM4_2-Irian.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM4_2-Irian.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": -0.97,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM4",
     "Description" : {
         "Cost" : 70000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM4_2-Irian.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM4_2-Irian.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM4",
     "Description" : {
         "Cost" : 70000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM4_2-Valiant.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM4_2-Valiant.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 4,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM4",
     "Description" : {
         "Cost" : 80000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM4_2-Valiant.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM4_2-Valiant.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 4,
-    "AMSHitChance": -0.97,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM4",
     "Description" : {
         "Cost" : 80000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM4_3-Valiant.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM4_3-Valiant.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 5,
-    "AMSHitChance": -0.97,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM4",
     "Description" : {
         "Cost" : 90000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM4_3-Valiant.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM4_3-Valiant.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 5,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM4",
     "Description" : {
         "Cost" : 90000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM6_0-STOCK.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM6_0-STOCK.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": -0.97,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM6",
     "Description" : {
         "Cost" : 90000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM6_0-STOCK.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM6_0-STOCK.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM6",
     "Description" : {
         "Cost" : 90000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM6_1-Holly.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM6_1-Holly.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": -0.97,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM6",
     "Description" : {
         "Cost" : 140000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM6_1-Holly.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM6_1-Holly.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM6",
     "Description" : {
         "Cost" : 140000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM6_1-Irian.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM6_1-Irian.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM6",
     "Description" : {
         "Cost" : 100000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM6_1-Irian.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM6_1-Irian.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": -0.97,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM6",
     "Description" : {
         "Cost" : 100000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM6_2-Holly.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM6_2-Holly.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": -0.97,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM6",
     "Description" : {
         "Cost" : 330000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM6_2-Holly.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM6_2-Holly.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM6",
     "Description" : {
         "Cost" : 330000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM6_2-Irian.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM6_2-Irian.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM6",
     "Description" : {
         "Cost" : 100000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM6_2-Irian.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM6_2-Irian.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 3,
-    "AMSHitChance": -0.97,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM6",
     "Description" : {
         "Cost" : 100000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM6_2-Valiant.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM6_2-Valiant.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 4,
-    "AMSHitChance": -0.97,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM6",
     "Description" : {
         "Cost" : 120000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM6_2-Valiant.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM6_2-Valiant.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 4,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM6",
     "Description" : {
         "Cost" : 120000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM6_3-Valiant.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM6_3-Valiant.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 5,
-    "AMSHitChance": -0.97,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM6",
     "Description" : {
         "Cost" : 140000,

--- a/BD Weapon Rebalance/weapons/Weapon_SRM_SRM6_3-Valiant.json
+++ b/BD Weapon Rebalance/weapons/Weapon_SRM_SRM6_3-Valiant.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 5,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_SRM6",
     "Description" : {
         "Cost" : 140000,

--- a/BT Advanced Gear/weapon/Weapon_AMS.json
+++ b/BT Advanced Gear/weapon/Weapon_AMS.json
@@ -79,7 +79,7 @@
             "isBaseMode": true,
             "AMSShootsEveryAttack": false,
             "ShotsWhenFired": 25,
-            "AMSHitChance": 0.98
+            "AMSHitChance": 0.02
         },
         {
             "Id": "Overload",
@@ -87,7 +87,7 @@
             "isBaseMode": false,
             "AMSShootsEveryAttack": true,
             "ShotsWhenFired": 25,
-            "AMSHitChance": 0.98,
+            "AMSHitChance": 0.02,
             "FlatJammingChance": 0.30,
             "HeatGenerated": 2
         },

--- a/BT Advanced Gear/weapon/Weapon_AMS.json
+++ b/BT Advanced Gear/weapon/Weapon_AMS.json
@@ -8,7 +8,7 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "AMS",
-                "AMSShots: 50",
+                "AMSShots: 25",
                 "OLAMSHeat: 2",
                 "OLAMSJam: 30%"
             ]
@@ -29,7 +29,7 @@
     ],
     "AmmoCategory": "AntiMissile",
     "StartingAmmoCapacity": 0,
-    "HeatGenerated": 0,
+    "HeatGenerated": 3,
     "Damage": 0,
     "OverheatedDamageMultiplier": 0,
     "EvasiveDamageMultiplier": 0,
@@ -77,16 +77,17 @@
             "Id": "On",
             "UIName": "On",
             "isBaseMode": true,
-            "ShotsWhenFired": 50,
-            "AMSHitChance": 1
+            "AMSShootsEveryAttack": false,
+            "ShotsWhenFired": 25,
+            "AMSHitChance": 0.98
         },
         {
             "Id": "Overload",
             "UIName": "Overload",
             "isBaseMode": false,
             "AMSShootsEveryAttack": true,
-            "ShotsWhenFired": 50,
-            "AMSHitChance": 1,
+            "ShotsWhenFired": 25,
+            "AMSHitChance": 0.98,
             "FlatJammingChance": 0.30,
             "HeatGenerated": 2
         },

--- a/BT Advanced Gear/weapon/Weapon_LRM_Thunderbolt10.json
+++ b/BT Advanced Gear/weapon/Weapon_LRM_Thunderbolt10.json
@@ -38,7 +38,7 @@
     "ProjectilesPerShot": 1,
     "AttackRecoil": 1,
     "Instability": 11,
-	"AMSHitChance": 1,
+	"AMSHitChance": 0,
     "WeaponEffectID": "WeaponEffect-Weapon_LRM10",
     "Description": {
         "Cost": 300000,

--- a/BT Advanced Gear/weapon/Weapon_LRM_Thunderbolt10.json
+++ b/BT Advanced Gear/weapon/Weapon_LRM_Thunderbolt10.json
@@ -38,7 +38,7 @@
     "ProjectilesPerShot": 1,
     "AttackRecoil": 1,
     "Instability": 11,
-	"AMSHitChance": -0.95,
+	"AMSHitChance": 1,
     "WeaponEffectID": "WeaponEffect-Weapon_LRM10",
     "Description": {
         "Cost": 300000,

--- a/BT Advanced Gear/weapon/Weapon_LRM_Thunderbolt15.json
+++ b/BT Advanced Gear/weapon/Weapon_LRM_Thunderbolt15.json
@@ -38,7 +38,7 @@
     "ProjectilesPerShot": 1,
     "AttackRecoil": 1,
     "Instability": 16,
-	"AMSHitChance": 1,
+	"AMSHitChance": 0,
     "WeaponEffectID": "WeaponEffect-Weapon_LRM15",
     "Description": {
         "Cost": 400000,

--- a/BT Advanced Gear/weapon/Weapon_LRM_Thunderbolt15.json
+++ b/BT Advanced Gear/weapon/Weapon_LRM_Thunderbolt15.json
@@ -38,7 +38,7 @@
     "ProjectilesPerShot": 1,
     "AttackRecoil": 1,
     "Instability": 16,
-	"AMSHitChance": -0.95,
+	"AMSHitChance": 1,
     "WeaponEffectID": "WeaponEffect-Weapon_LRM15",
     "Description": {
         "Cost": 400000,

--- a/BT Advanced Gear/weapon/Weapon_LRM_Thunderbolt20.json
+++ b/BT Advanced Gear/weapon/Weapon_LRM_Thunderbolt20.json
@@ -38,7 +38,7 @@
     "ProjectilesPerShot": 1,
     "AttackRecoil": 1,
     "Instability": 20,
-	"AMSHitChance": -0.95,
+	"AMSHitChance": 1,
     "WeaponEffectID": "WeaponEffect-Weapon_LRM20",
     "Description": {
         "Cost": 500000,

--- a/BT Advanced Gear/weapon/Weapon_LRM_Thunderbolt20.json
+++ b/BT Advanced Gear/weapon/Weapon_LRM_Thunderbolt20.json
@@ -38,7 +38,7 @@
     "ProjectilesPerShot": 1,
     "AttackRecoil": 1,
     "Instability": 20,
-	"AMSHitChance": 1,
+	"AMSHitChance": 0,
     "WeaponEffectID": "WeaponEffect-Weapon_LRM20",
     "Description": {
         "Cost": 500000,

--- a/BT Advanced Gear/weapon/Weapon_LRM_Thunderbolt5.json
+++ b/BT Advanced Gear/weapon/Weapon_LRM_Thunderbolt5.json
@@ -38,7 +38,7 @@
     "ProjectilesPerShot": 1,
     "AttackRecoil": 1,
     "Instability": 6,
-	"AMSHitChance": -0.95,
+	"AMSHitChance": 1,
     "WeaponEffectID": "WeaponEffect-Weapon_LRM5",
     "Description": {
         "Cost": 200000,

--- a/BT Advanced Gear/weapon/Weapon_LRM_Thunderbolt5.json
+++ b/BT Advanced Gear/weapon/Weapon_LRM_Thunderbolt5.json
@@ -38,7 +38,7 @@
     "ProjectilesPerShot": 1,
     "AttackRecoil": 1,
     "Instability": 6,
-	"AMSHitChance": 1,
+	"AMSHitChance": 0,
     "WeaponEffectID": "WeaponEffect-Weapon_LRM5",
     "Description": {
         "Cost": 200000,

--- a/BT Advanced Gear/weapon/Weapon_Laser_AMS.json
+++ b/BT Advanced Gear/weapon/Weapon_Laser_AMS.json
@@ -80,7 +80,7 @@
             "isBaseMode": true,
             "AMSShootsEveryAttack": false,
             "ShotsWhenFired": 25,
-            "AMSHitChance": 0.98
+            "AMSHitChance": 0.02
         },
         {
             "Id": "Overload",
@@ -88,7 +88,7 @@
             "isBaseMode": false,
             "AMSShootsEveryAttack": true,
             "ShotsWhenFired": 25,
-            "AMSHitChance": 0.98,
+            "AMSHitChance": 0.02,
             "FlatJammingChance": 0.3,
             "HeatGenerated": 6
         },

--- a/BT Advanced Gear/weapon/Weapon_Laser_AMS.json
+++ b/BT Advanced Gear/weapon/Weapon_Laser_AMS.json
@@ -8,7 +8,7 @@
         "BonusDescriptions": {
             "Bonuses": [
                 "LAMS",
-                "AMSShots: 50",
+                "AMSShots: 25",
                 "AMSHeat: 6",
                 "OLAMSHeat: 18",
                 "OLAMSJam: 30%"
@@ -78,18 +78,19 @@
             "Id": "On",
             "UIName": "On",
             "isBaseMode": true,
-            "ShotsWhenFired": 50,
-            "AMSHitChance": 1
+            "AMSShootsEveryAttack": false,
+            "ShotsWhenFired": 25,
+            "AMSHitChance": 0.98
         },
         {
             "Id": "Overload",
             "UIName": "Overload",
             "isBaseMode": false,
             "AMSShootsEveryAttack": true,
-            "ShotsWhenFired": 50,
-            "AMSHitChance": 1,
+            "ShotsWhenFired": 25,
+            "AMSHitChance": 0.98,
             "FlatJammingChance": 0.3,
-            "HeatGenerated": 12
+            "HeatGenerated": 6
         },
         {
             "Id": "Off",

--- a/BT Advanced Gear/weapon/Weapon_MRM_MRM10_0-STOCK.json
+++ b/BT Advanced Gear/weapon/Weapon_MRM_MRM10_0-STOCK.json
@@ -41,7 +41,7 @@
     "ProjectilesPerShot": 1,
     "AttackRecoil": 1,
     "Instability": 1,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID": "WeaponEffect-Weapon_SRM6",
     "Description": {
         "Cost": 120000,

--- a/BT Advanced Gear/weapon/Weapon_MRM_MRM10_0-STOCK.json
+++ b/BT Advanced Gear/weapon/Weapon_MRM_MRM10_0-STOCK.json
@@ -41,7 +41,7 @@
     "ProjectilesPerShot": 1,
     "AttackRecoil": 1,
     "Instability": 1,
-    "AMSHitChance": -0.94,
+    "AMSHitChance": 1,
     "WeaponEffectID": "WeaponEffect-Weapon_SRM6",
     "Description": {
         "Cost": 120000,

--- a/BT Advanced Gear/weapon/Weapon_MRM_MRM20_0-STOCK.json
+++ b/BT Advanced Gear/weapon/Weapon_MRM_MRM20_0-STOCK.json
@@ -41,7 +41,7 @@
     "ProjectilesPerShot": 1,
     "AttackRecoil": 1,
     "Instability": 1,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID": "WeaponEffect-Weapon_SRM6",
     "Description": {
         "Cost": 225000,

--- a/BT Advanced Gear/weapon/Weapon_MRM_MRM20_0-STOCK.json
+++ b/BT Advanced Gear/weapon/Weapon_MRM_MRM20_0-STOCK.json
@@ -41,7 +41,7 @@
     "ProjectilesPerShot": 1,
     "AttackRecoil": 1,
     "Instability": 1,
-    "AMSHitChance": -0.94,
+    "AMSHitChance": 1,
     "WeaponEffectID": "WeaponEffect-Weapon_SRM6",
     "Description": {
         "Cost": 225000,

--- a/BT Advanced Gear/weapon/Weapon_MRM_MRM30_0-STOCK.json
+++ b/BT Advanced Gear/weapon/Weapon_MRM_MRM30_0-STOCK.json
@@ -41,7 +41,7 @@
     "ProjectilesPerShot": 1,
     "AttackRecoil": 1,
     "Instability": 1,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID": "WeaponEffect-Weapon_SRM6",
     "Description": {
         "Cost": 330000,

--- a/BT Advanced Gear/weapon/Weapon_MRM_MRM30_0-STOCK.json
+++ b/BT Advanced Gear/weapon/Weapon_MRM_MRM30_0-STOCK.json
@@ -41,7 +41,7 @@
     "ProjectilesPerShot": 1,
     "AttackRecoil": 1,
     "Instability": 1,
-    "AMSHitChance": -0.94,
+    "AMSHitChance": 1,
     "WeaponEffectID": "WeaponEffect-Weapon_SRM6",
     "Description": {
         "Cost": 330000,

--- a/BT Advanced Gear/weapon/Weapon_MRM_MRM40_0-STOCK.json
+++ b/BT Advanced Gear/weapon/Weapon_MRM_MRM40_0-STOCK.json
@@ -41,7 +41,7 @@
     "ProjectilesPerShot": 1,
     "AttackRecoil": 1,
     "Instability": 1,
-    "AMSHitChance": -0.94,
+    "AMSHitChance": 1,
     "WeaponEffectID": "WeaponEffect-Weapon_SRM6",
     "Description": {
         "Cost": 435000,

--- a/BT Advanced Gear/weapon/Weapon_MRM_MRM40_0-STOCK.json
+++ b/BT Advanced Gear/weapon/Weapon_MRM_MRM40_0-STOCK.json
@@ -41,7 +41,7 @@
     "ProjectilesPerShot": 1,
     "AttackRecoil": 1,
     "Instability": 1,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID": "WeaponEffect-Weapon_SRM6",
     "Description": {
         "Cost": 435000,

--- a/BT Advanced Gear/weapon/Weapon_RocketLauncher_RL10_0_STOCK.json
+++ b/BT Advanced Gear/weapon/Weapon_RocketLauncher_RL10_0_STOCK.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 2,
-    "AMSHitChance": -0.98,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM10",
     "Description" : {
         "Cost" : 50000,

--- a/BT Advanced Gear/weapon/Weapon_RocketLauncher_RL10_0_STOCK.json
+++ b/BT Advanced Gear/weapon/Weapon_RocketLauncher_RL10_0_STOCK.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 2,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM10",
     "Description" : {
         "Cost" : 50000,

--- a/BT Advanced Gear/weapon/Weapon_RocketLauncher_RL15_0_STOCK.json
+++ b/BT Advanced Gear/weapon/Weapon_RocketLauncher_RL15_0_STOCK.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 2,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM15",
     "Description" : {
         "Cost" : 75000,

--- a/BT Advanced Gear/weapon/Weapon_RocketLauncher_RL15_0_STOCK.json
+++ b/BT Advanced Gear/weapon/Weapon_RocketLauncher_RL15_0_STOCK.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 2,
-    "AMSHitChance": -0.98,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM15",
     "Description" : {
         "Cost" : 75000,

--- a/BT Advanced Gear/weapon/Weapon_RocketLauncher_RL20_0_STOCK.json
+++ b/BT Advanced Gear/weapon/Weapon_RocketLauncher_RL20_0_STOCK.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 2,
-    "AMSHitChance": -0.98,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM20",
     "Description" : {
         "Cost" : 100000,

--- a/BT Advanced Gear/weapon/Weapon_RocketLauncher_RL20_0_STOCK.json
+++ b/BT Advanced Gear/weapon/Weapon_RocketLauncher_RL20_0_STOCK.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 2,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM20",
     "Description" : {
         "Cost" : 100000,

--- a/BT Advanced Gear/weapon/Weapon_RocketLauncher_RL40_0_STOCK.json
+++ b/BT Advanced Gear/weapon/Weapon_RocketLauncher_RL40_0_STOCK.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 2,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM20",
     "Description" : {
         "Cost" : 250000,

--- a/BT Advanced Gear/weapon/Weapon_RocketLauncher_RL40_0_STOCK.json
+++ b/BT Advanced Gear/weapon/Weapon_RocketLauncher_RL40_0_STOCK.json
@@ -27,7 +27,7 @@
     "ProjectilesPerShot" : 1,
     "AttackRecoil" : 1,
     "Instability" : 2,
-    "AMSHitChance": -0.98,
+    "AMSHitChance": 1,
     "WeaponEffectID" : "WeaponEffect-Weapon_LRM20",
     "Description" : {
         "Cost" : 250000,

--- a/BT Advanced Gear/weapon/Weapon_SRM_SRM_NARC.json
+++ b/BT Advanced Gear/weapon/Weapon_SRM_SRM_NARC.json
@@ -39,7 +39,7 @@
     "ProjectilesPerShot": 1,
     "AttackRecoil": 1,
     "Instability": 0,
-	"AMSHitChance": -0.99,
+	"AMSHitChance": 1,
 	"NotUseInMelee": true,
     "WeaponEffectID": "WeaponEffect-Weapon_SRM2",
     "Description": {

--- a/BT Advanced Gear/weapon/Weapon_SRM_SRM_NARC.json
+++ b/BT Advanced Gear/weapon/Weapon_SRM_SRM_NARC.json
@@ -39,7 +39,7 @@
     "ProjectilesPerShot": 1,
     "AttackRecoil": 1,
     "Instability": 0,
-	"AMSHitChance": 1,
+	"AMSHitChance": 0,
 	"NotUseInMelee": true,
     "WeaponEffectID": "WeaponEffect-Weapon_SRM2",
     "Description": {

--- a/BT Advanced Gear/weapon/Weapon_SRM_SSRM2_0-STOCK.json
+++ b/BT Advanced Gear/weapon/Weapon_SRM_SSRM2_0-STOCK.json
@@ -45,7 +45,7 @@
     "AttackRecoil": 1,
     "Instability": 3,
     "FireTerrainChance": 0.01,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID": "WeaponEffect-Weapon_SRM2",
     "Description": {
         "Cost": 450000,

--- a/BT Advanced Gear/weapon/Weapon_SRM_SSRM2_0-STOCK.json
+++ b/BT Advanced Gear/weapon/Weapon_SRM_SSRM2_0-STOCK.json
@@ -45,7 +45,7 @@
     "AttackRecoil": 1,
     "Instability": 3,
     "FireTerrainChance": 0.01,
-    "AMSHitChance": -0.96,
+    "AMSHitChance": 1,
     "WeaponEffectID": "WeaponEffect-Weapon_SRM2",
     "Description": {
         "Cost": 450000,

--- a/BT Advanced Gear/weapon/Weapon_SRM_SSRM4_0-STOCK.json
+++ b/BT Advanced Gear/weapon/Weapon_SRM_SSRM4_0-STOCK.json
@@ -45,7 +45,7 @@
     "AttackRecoil": 1,
     "Instability": 3,
     "FireTerrainChance": 0.01,
-    "AMSHitChance": -0.96,
+    "AMSHitChance": 1,
     "WeaponEffectID": "WeaponEffect-Weapon_SRM4",
     "Description": {
         "Cost": 580000,

--- a/BT Advanced Gear/weapon/Weapon_SRM_SSRM4_0-STOCK.json
+++ b/BT Advanced Gear/weapon/Weapon_SRM_SSRM4_0-STOCK.json
@@ -45,7 +45,7 @@
     "AttackRecoil": 1,
     "Instability": 3,
     "FireTerrainChance": 0.01,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID": "WeaponEffect-Weapon_SRM4",
     "Description": {
         "Cost": 580000,

--- a/BT Advanced Gear/weapon/Weapon_SRM_SSRM6_0-STOCK.json
+++ b/BT Advanced Gear/weapon/Weapon_SRM_SSRM6_0-STOCK.json
@@ -45,7 +45,7 @@
     "AttackRecoil": 1,
     "Instability": 3,
     "FireTerrainChance": 0.01,
-    "AMSHitChance": -0.96,
+    "AMSHitChance": 1,
     "WeaponEffectID": "WeaponEffect-Weapon_SRM6",
     "Description": {
         "Cost": 620000,

--- a/BT Advanced Gear/weapon/Weapon_SRM_SSRM6_0-STOCK.json
+++ b/BT Advanced Gear/weapon/Weapon_SRM_SSRM6_0-STOCK.json
@@ -45,7 +45,7 @@
     "AttackRecoil": 1,
     "Instability": 3,
     "FireTerrainChance": 0.01,
-    "AMSHitChance": 1,
+    "AMSHitChance": 0,
     "WeaponEffectID": "WeaponEffect-Weapon_SRM6",
     "Description": {
         "Cost": 620000,

--- a/CustomAmmoCategories/ammunition/Ammunition_LRM_Deadfire.json
+++ b/CustomAmmoCategories/ammunition/Ammunition_LRM_Deadfire.json
@@ -27,6 +27,6 @@
    "ShortRange": -80.0,
    "MiddleRange": -170.0,
    "LongRange": -250.0,
-   "AMSHitChance": -0.025,
+   "AMSHitChance": -0.01,
    "Unguided": true
 }

--- a/CustomAmmoCategories/ammunition/Ammunition_LRM_LK.json
+++ b/CustomAmmoCategories/ammunition/Ammunition_LRM_LK.json
@@ -17,5 +17,5 @@
    "ArmorDamageModifier": 1,
    "ISDamageModifier": 1,
    "CriticalDamageModifier": 1,
-   "AMSHitChance": 0.035
+   "AMSHitChance": 0.01
 }


### PR DESCRIPTION
Shot count halved to 25 per round.
Approach simplified for easier testing, no differences between launcher types just a flat chance for everything so we can see what's going on more easily. Touches fewer files than before.