### PR TITLE
Narc ammo enum fix

### DIFF
--- a/BT Advanced Core/AmmoCategory.json
+++ b/BT Advanced Core/AmmoCategory.json
@@ -1069,13 +1069,13 @@
 			"Name": "NARC",
 			"FriendlyName": "NARC",
 			"IsBallistic": false,
-			"IsMissile": false,
+			"IsMissile": true,
 			"IsEnergy": false,
-			"IsSupport": true,
+			"IsSupport": false,
 			"UsesInternalAmmo": false,
-			"UIColorRef": "Small",
+			"UIColorRef": "Missile",
 			"FallbackUIColor": null,
-			"Icon": "SmallHardpointIcon",
+			"Icon": "MissileHardpointIcon",
 			"OutOfAmmoAudioVOEvent": "AmmoDepleted_SRM"
 		},
 		{


### PR DESCRIPTION
Narc ammo now shows up where it should, in missiles not support