### PR TITLE
Fix for Clash Of Titans contract

### DIFF
--- a/BT Advanced Contracts/contract/threewaybattle/8/ThreeWayBattle_ClashOfTitans.json
+++ b/BT Advanced Contracts/contract/threewaybattle/8/ThreeWayBattle_ClashOfTitans.json
@@ -3309,7 +3309,9 @@
                             "tagSetSourceFile": "tags/UnitTags"
                         },
                         "unitExcludedTagSet": {
-                            "items": [],
+                            "items": [
+                                "unit_vehicle"
+                            ],
                             "tagSetSourceFile": "tags/UnitTags"
                         },
                         "spawnEffectTags": {
@@ -4799,7 +4801,9 @@
                             "tagSetSourceFile": "tags/UnitTags"
                         },
                         "unitExcludedTagSet": {
-                            "items": [],
+                            "items": [
+                                "unit_vehicle"
+                            ],
                             "tagSetSourceFile": "tags/UnitTags"
                         },
                         "spawnEffectTags": {


### PR DESCRIPTION
Fixed the contract being able to spawn assault-grade vehicles as the target instead of an Assault Mech. Didn't crash on test and could still produce vehicles as escorts.