### PR TITLE
Arano Restoration Flashpoint

### DIFF
--- a/Flashpoint DLC Flashpoints/flashpoints/fp_SiegeAttackItrom.json
+++ b/Flashpoint DLC Flashpoints/flashpoints/fp_SiegeAttackItrom.json
@@ -29,7 +29,7 @@
 		"Scope": "StarSystem",
 		"RequirementTags": {
 			"items": [
-				"planet_name_itrom_flipped"
+				"planet_name_itrom"
 			],
 			"tagSetSourceFile": "Tags/PlanetNameTags"
 		},

--- a/Flashpoint DLC Flashpoints/flashpoints/fp_SiegeAttackPanzer.json
+++ b/Flashpoint DLC Flashpoints/flashpoints/fp_SiegeAttackPanzer.json
@@ -29,7 +29,7 @@
 		"Scope": "StarSystem",
 		"RequirementTags": {
 			"items": [
-				"planet_name_panzer_flipped"
+				"planet_name_panzer"
 			],
 			"tagSetSourceFile": "Tags/PlanetNameTags"
 		},

--- a/Flashpoint DLC Flashpoints/flashpoints/fp_SiegeAttackSmithon.json
+++ b/Flashpoint DLC Flashpoints/flashpoints/fp_SiegeAttackSmithon.json
@@ -29,7 +29,7 @@
 		"Scope": "StarSystem",
 		"RequirementTags": {
 			"items": [
-				"planet_name_smithon_flipped"
+				"planet_name_smithon"
 			],
 			"tagSetSourceFile": "Tags/PlanetNameTags"
 		},

--- a/Flashpoint DLC Flashpoints/flashpoints/fp_SiegeDefendItrom.json
+++ b/Flashpoint DLC Flashpoints/flashpoints/fp_SiegeDefendItrom.json
@@ -27,7 +27,7 @@
 		"Scope": "StarSystem",
 		"RequirementTags": {
 			"items": [
-				"planet_name_itrom_flipped"
+				"planet_name_itrom"
 			],
 			"tagSetSourceFile": "Tags/PlanetNameTags"
 		},

--- a/Flashpoint DLC Flashpoints/flashpoints/fp_SiegeDefendPanzer.json
+++ b/Flashpoint DLC Flashpoints/flashpoints/fp_SiegeDefendPanzer.json
@@ -27,7 +27,7 @@
 		"Scope": "StarSystem",
 		"RequirementTags": {
 			"items": [
-				"planet_name_panzer_flipped"
+				"planet_name_panzer"
 			],
 			"tagSetSourceFile": "Tags/PlanetNameTags"
 		},

--- a/Flashpoint DLC Flashpoints/flashpoints/fp_SiegeDefendSmithon.json
+++ b/Flashpoint DLC Flashpoints/flashpoints/fp_SiegeDefendSmithon.json
@@ -27,7 +27,7 @@
 		"Scope": "StarSystem",
 		"RequirementTags": {
 			"items": [
-				"planet_name_smithon_flipped"
+				"planet_name_smithon"
 			],
 			"tagSetSourceFile": "Tags/PlanetNameTags"
 		},

--- a/Flashpoint DLC Flashpoints/flashpoints/fp_StoryTime1.json
+++ b/Flashpoint DLC Flashpoints/flashpoints/fp_StoryTime1.json
@@ -29,7 +29,7 @@
         "Scope": "StarSystem",
         "RequirementTags": {
             "items": [
-				"planet_name_coromodir_flipped"
+				"planet_name_coromodir"
 			],
             "tagSetSourceFile": "Tags/PlanetNameTags"
         },

--- a/Flashpoint DLC Flashpoints/flashpoints/fp_StoryTime2.json
+++ b/Flashpoint DLC Flashpoints/flashpoints/fp_StoryTime2.json
@@ -31,7 +31,7 @@
         "Scope": "StarSystem",
         "RequirementTags": {
             "items": [
-				"planet_name_urcruinne_career"
+				"planet_name_urcruinne"
 			],
             "tagSetSourceFile": "Tags/PlanetNameTags"
         },

--- a/Flashpoint DLC Flashpoints/flashpoints/fp_StoryTime3.json
+++ b/Flashpoint DLC Flashpoints/flashpoints/fp_StoryTime3.json
@@ -31,7 +31,7 @@
         "Scope": "StarSystem",
         "RequirementTags": {
             "items": [
-				"planet_name_bellerophon_career"
+				"planet_name_bellerophon"
 			],
             "tagSetSourceFile": "Tags/PlanetNameTags"
         },

--- a/Flashpoint DLC Flashpoints/flashpoints/fp_StoryTime4.json
+++ b/Flashpoint DLC Flashpoints/flashpoints/fp_StoryTime4.json
@@ -31,7 +31,7 @@
         "Scope": "StarSystem",
         "RequirementTags": {
             "items": [
-				"planet_name_weldry_flipped"
+				"planet_name_weldry"
 			],
             "tagSetSourceFile": "Tags/PlanetNameTags"
         },

--- a/Flashpoint DLC Flashpoints/flashpoints/fp_StoryTime5.json
+++ b/Flashpoint DLC Flashpoints/flashpoints/fp_StoryTime5.json
@@ -31,7 +31,7 @@
         "Scope": "StarSystem",
         "RequirementTags": {
             "items": [
-				"planet_name_smithon_flipped"
+				"planet_name_smithon"
 			],
             "tagSetSourceFile": "Tags/PlanetNameTags"
         },

--- a/Flashpoint DLC Flashpoints/flashpoints/fp_StoryTime6.json
+++ b/Flashpoint DLC Flashpoints/flashpoints/fp_StoryTime6.json
@@ -31,7 +31,7 @@
         "Scope": "StarSystem",
         "RequirementTags": {
             "items": [
-				"planet_name_artru_flipped"
+				"planet_name_artru"
 			],
             "tagSetSourceFile": "Tags/PlanetNameTags"
         },

--- a/Flashpoint DLC Flashpoints/flashpoints/fp_StoryTime7.json
+++ b/Flashpoint DLC Flashpoints/flashpoints/fp_StoryTime7.json
@@ -31,7 +31,7 @@
         "Scope": "StarSystem",
         "RequirementTags": {
             "items": [
-				"planet_name_guldra_flipped"
+				"planet_name_guldra"
 			],
             "tagSetSourceFile": "Tags/PlanetNameTags"
         },

--- a/Flashpoint DLC Flashpoints/flashpoints/fp_StoryTime8.json
+++ b/Flashpoint DLC Flashpoints/flashpoints/fp_StoryTime8.json
@@ -31,7 +31,7 @@
         "Scope": "StarSystem",
         "RequirementTags": {
             "items": [
-				"planet_name_coromodir_flipped"
+				"planet_name_coromodir"
 			],
             "tagSetSourceFile": "Tags/PlanetNameTags"
         },

--- a/Flashpoint DLC Flashpoints/flashpoints/fp_StoryTime9.json
+++ b/Flashpoint DLC Flashpoints/flashpoints/fp_StoryTime9.json
@@ -31,7 +31,7 @@
         "Scope": "StarSystem",
         "RequirementTags": {
             "items": [
-				"planet_name_coromodir_flipped"
+				"planet_name_coromodir"
 			],
             "tagSetSourceFile": "Tags/PlanetNameTags"
         },

--- a/MechEngineer/Settings.json
+++ b/MechEngineer/Settings.json
@@ -362,7 +362,10 @@
 					"lbx2",
 					"ac",
 					"lbx",
-					"mg"
+					"ppc",
+					"laser",
+					"mg",
+					"flamer"
 				]
 			},
 			{
@@ -374,6 +377,8 @@
 					"lbx5",
 					"ac",
 					"lbx",
+					"ppc",
+					"laser",
 					"mg"
 				]
 			},
@@ -385,7 +390,10 @@
 					"lbx10",
 					"ac",
 					"lbx",
-					"mg"
+					"ppc",
+					"laser",
+					"mg",
+					"flamer"
 				]
 			},
 			{
@@ -395,7 +403,27 @@
 					"uac20",
 					"ac",
 					"lbx",
-					"mg"
+					"ppc",
+					"laser",
+					"mg",
+					"flamer",
+					"ams"
+				]
+			},
+			{
+				"PrefabIdentifier": "lbx10",
+				"HardpointCandidates": [
+					"lbx10",
+					"lbx20",
+					"lbx5",
+					"lbx2",
+					"ac10",
+					"ac",
+					"lbx",
+					"ppc",
+					"laser",
+					"mg",
+					"flamer"
 				]
 			},
 			{
@@ -413,7 +441,10 @@
 					"lbx5",
 					"ac",
 					"lbx",
-					"mg"
+					"ppc",
+					"laser",
+					"mg",
+					"flamer"
 				]
 			},
 			{
@@ -505,7 +536,9 @@
 					"machinegun",
 					"mg",
 					"lmg",
-					"hmg"
+					"flamer",
+					"laser",
+					"ams"
 				]
 			},
 			{
@@ -556,7 +589,15 @@
 					"ppc",
 					"hppc",
 					"lppc",
-					"snppc"
+					"ac20",
+					"ac",
+					"lbx",
+					"ac10",
+					"lbx10",
+					"laser",
+					"flamer",
+					"mg",
+					"ams"
 				]
 			},
 			{
@@ -564,7 +605,22 @@
 				"HardpointCandidates": [
 					"gauss",
 					"hgauss",
-					"lgauss"
+					"sbgauss",
+					"ac20",
+					"ac",
+					"ppc",
+					"lbx",
+					"laser",
+					"srm2",
+					"srm4",
+					"srm6",
+					"lrm5",
+					"lrm10",
+					"lrm15",
+					"lrm20",
+					"mg",
+					"flamer",
+					"ams"
 				]
 			},
 			{
@@ -590,6 +646,33 @@
 					"mg",
 					"machinegun",
 					"flamer",
+					"ac2",
+					"ppc",
+					"ac",
+					"lbx"
+				]
+			},
+			{
+				"PrefabIdentifier": "Flamer",
+				"HardpointCandidates": [
+					"flamer",
+					"laser",
+					"mg",
+					"machinegun",
+					"ac2",
+					"ppc",
+					"ac",
+					"lbx",
+					"ams"
+				]
+			},
+			{
+				"PrefabIdentifier": "Laser",
+				"HardpointCandidates": [
+					"laser",
+					"flamer",
+					"mg",
+					"machinegun",
 					"ac2",
 					"ppc",
 					"ac",

--- a/MechEngineer/Settings.json
+++ b/MechEngineer/Settings.json
@@ -307,36 +307,36 @@
 		],
 		"Enabled": true
 	},
-	"Engine" : {
-        "Enabled" : true,
-        "EnabledDescription" : "Provides engines that can be installed on mechs similar to how CBT works.",
-        "MovementPointDistanceMultiplierDescription" : "The distance of a TT movement point, 24 is vanilla CombatGameConstants.ExperimentalGridDistance .",
-        "MinimJumpHeatDescription" : "Minimum heat when doing a jump, even if only one jump jet exists and only when jumping one hex.",
-        "AutoConvertJumpCapacityInDefToStatDescription" : "All JumpCapacity values in JumpJetDefs will be auto-converted to the JumpCapacity statistic.",
-        "JumpJetDefaultJumpHeatDescription" : "The heat the jump jet produces when fully* used (* jumping below max distance reduces produced heat). Can be adjusted using the JumpHeat statistic.",
-        "RunMultiplierDescription" : "How much faster running is than walking.",
-        "EngineRatingForChassisMovementStatDescription" : "The engine rating to use when evaluating the movement stat of a mech.",
-        "AllowMountingAllRatings" : false,
-        "AllowMountingAllRatingsDescription" : "Allow mounting all fusion core rating regardless of min/max sprint factors.",
-        "MinimumHeatSinksOnMech" : 10,
-        "MinimumHeatSinksOnMechDescription" : "Minimum heatsinks a mech requires.",
-        "EnforceRulesForAdditionalInternalHeatSinks" : true,
-        "EnforceRulesForAdditionalInternalHeatSinksDescription" : "Can't have those juicy ++ cooling systems with smaller fusion cores than the rules allow it.",
-        "AllowMixingHeatSinkTypes" : false,
-        "AllowMixingHeatSinkTypesDescription" : "Allow heat sinks patchwork.",
-        "DefaultEngineHeatSinkId" : "Gear_HeatSink_Generic_Standard",
-        "DefaultEngineHeatSinkIdDescription" : "Default heat sink type for engines without a kit.",
-        "EngineMissingFallbackHeatSinkCapacity" : 30,
-        "EngineMissingFallbackHeatSinkCapacityDescription" : "Heat sink capacity if no engine is detected.",
-        "MovementPointDistanceMultiplier" : 28,
-        "MinimJumpHeat" : 9,
-        "AutoConvertJumpCapacityInDefToStat" : true,
-        "JumpJetDefaultJumpHeat" : 3,
-        "RunMultiplier" : 1.5,
-        "EngineRatingForChassisMovementStat" : 250,
-        "LimitEngineCoresToTonnage" : true,
-        "IgnoreLimitEngineChassisTag" : ""
-    },
+	"Engine": {
+		"Enabled": true,
+		"EnabledDescription": "Provides engines that can be installed on mechs similar to how CBT works.",
+		"MovementPointDistanceMultiplierDescription": "The distance of a TT movement point, 24 is vanilla CombatGameConstants.ExperimentalGridDistance .",
+		"MinimJumpHeatDescription": "Minimum heat when doing a jump, even if only one jump jet exists and only when jumping one hex.",
+		"AutoConvertJumpCapacityInDefToStatDescription": "All JumpCapacity values in JumpJetDefs will be auto-converted to the JumpCapacity statistic.",
+		"JumpJetDefaultJumpHeatDescription": "The heat the jump jet produces when fully* used (* jumping below max distance reduces produced heat). Can be adjusted using the JumpHeat statistic.",
+		"RunMultiplierDescription": "How much faster running is than walking.",
+		"EngineRatingForChassisMovementStatDescription": "The engine rating to use when evaluating the movement stat of a mech.",
+		"AllowMountingAllRatings": false,
+		"AllowMountingAllRatingsDescription": "Allow mounting all fusion core rating regardless of min/max sprint factors.",
+		"MinimumHeatSinksOnMech": 10,
+		"MinimumHeatSinksOnMechDescription": "Minimum heatsinks a mech requires.",
+		"EnforceRulesForAdditionalInternalHeatSinks": true,
+		"EnforceRulesForAdditionalInternalHeatSinksDescription": "Can't have those juicy ++ cooling systems with smaller fusion cores than the rules allow it.",
+		"AllowMixingHeatSinkTypes": false,
+		"AllowMixingHeatSinkTypesDescription": "Allow heat sinks patchwork.",
+		"DefaultEngineHeatSinkId": "Gear_HeatSink_Generic_Standard",
+		"DefaultEngineHeatSinkIdDescription": "Default heat sink type for engines without a kit.",
+		"EngineMissingFallbackHeatSinkCapacity": 30,
+		"EngineMissingFallbackHeatSinkCapacityDescription": "Heat sink capacity if no engine is detected.",
+		"MovementPointDistanceMultiplier": 28,
+		"MinimJumpHeat": 9,
+		"AutoConvertJumpCapacityInDefToStat": true,
+		"JumpJetDefaultJumpHeat": 3,
+		"RunMultiplier": 1.5,
+		"EngineRatingForChassisMovementStat": 250,
+		"LimitEngineCoresToTonnage": true,
+		"IgnoreLimitEngineChassisTag": ""
+	},
 	"HardpointFix": {
 		"Enabled": true,
 		"EnabledDescription": "Optimizes the way installed weapons are shown on a mech model.",
@@ -439,7 +439,12 @@
 					"lrm10",
 					"lrm15",
 					"lrm20",
-					"srm20"
+					"srm20",
+					"machinegun",
+					"mg",
+					"flamer",
+					"laser",
+					"ams"
 				]
 			},
 			{
@@ -450,7 +455,12 @@
 					"lrm20",
 					"srm20",
 					"lrm5",
-					"rl10"
+					"rl10",
+					"machinegun",
+					"mg",
+					"flamer",
+					"laser",
+					"ams"
 				]
 			},
 			{
@@ -463,7 +473,12 @@
 					"lrm5",
 					"rl20",
 					"rl15",
-					"rl10"
+					"rl10",
+					"machinegun",
+					"mg",
+					"flamer",
+					"laser",
+					"ams"
 				]
 			},
 			{
@@ -476,7 +491,12 @@
 					"lrm5",
 					"rl20",
 					"rl15",
-					"rl10"
+					"rl10",
+					"machinegun",
+					"mg",
+					"flamer",
+					"laser",
+					"ams"
 				]
 			},
 			{
@@ -494,7 +514,12 @@
 					"srm2",
 					"srm4",
 					"srm6",
-					"lrm5"
+					"lrm5",
+					"machinegun",
+					"mg",
+					"flamer",
+					"laser",
+					"ams"
 				]
 			},
 			{
@@ -503,7 +528,12 @@
 					"srm4",
 					"srm6",
 					"srm2",
-					"lrm5"
+					"lrm5",
+					"machinegun",
+					"mg",
+					"flamer",
+					"laser",
+					"ams"
 				]
 			},
 			{
@@ -512,7 +542,12 @@
 					"srm6",
 					"srm4",
 					"srm2",
-					"lrm5"
+					"lrm5",
+					"machinegun",
+					"mg",
+					"flamer",
+					"laser",
+					"ams"
 				]
 			},
 			{
@@ -539,7 +574,12 @@
 					"lrm20",
 					"lrm15",
 					"lrm10",
-					"lrm5"
+					"lrm5",
+					"machinegun",
+					"mg",
+					"flamer",
+					"laser",
+					"ams"
 				]
 			},
 			{


### PR DESCRIPTION
Planet names changed, only seem to be one name for each planet and not multiple that they had for campaign planets