### PR TITLE
Fixed missing FP faction tag

### DIFF
--- a/BT Advanced Custom Mechs/mech/mechdef_atlas_AS7-R.json
+++ b/BT Advanced Custom Mechs/mech/mechdef_atlas_AS7-R.json
@@ -37,6 +37,7 @@
 			"GraysGhosts",
 			"BroadswordLegion",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Custom Mechs/mech/mechdef_awesome_AWS-10Q.json
+++ b/BT Advanced Custom Mechs/mech/mechdef_awesome_AWS-10Q.json
@@ -31,6 +31,7 @@
 			"GraysGhosts",
 			"BroadswordLegion",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Custom Mechs/mech/mechdef_bombard_BMB-020.json
+++ b/BT Advanced Custom Mechs/mech/mechdef_bombard_BMB-020.json
@@ -27,6 +27,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Custom Mechs/mech/mechdef_champion_CHP-2X.json
+++ b/BT Advanced Custom Mechs/mech/mechdef_champion_CHP-2X.json
@@ -35,6 +35,7 @@
 			"GraysGhosts",
 			"BroadswordLegion",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Custom Mechs/mech/mechdef_charger_CGR-1B1.json
+++ b/BT Advanced Custom Mechs/mech/mechdef_charger_CGR-1B1.json
@@ -33,6 +33,7 @@
 			"GraysGhosts",
 			"BroadswordLegion",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Custom Mechs/mech/mechdef_charger_CGR-1R1.json
+++ b/BT Advanced Custom Mechs/mech/mechdef_charger_CGR-1R1.json
@@ -33,6 +33,7 @@
 			"GraysGhosts",
 			"BroadswordLegion",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Custom Mechs/mech/mechdef_charger_CGR-4A4.json
+++ b/BT Advanced Custom Mechs/mech/mechdef_charger_CGR-4A4.json
@@ -33,6 +33,7 @@
 			"GraysGhosts",
 			"BroadswordLegion",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Custom Mechs/mech/mechdef_corsair_COR-4A.json
+++ b/BT Advanced Custom Mechs/mech/mechdef_corsair_COR-4A.json
@@ -31,6 +31,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Custom Mechs/mech/mechdef_corsair_COR-8R.json
+++ b/BT Advanced Custom Mechs/mech/mechdef_corsair_COR-8R.json
@@ -31,6 +31,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Custom Mechs/mech/mechdef_dervish_DV-10K.json
+++ b/BT Advanced Custom Mechs/mech/mechdef_dervish_DV-10K.json
@@ -31,6 +31,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Custom Mechs/mech/mechdef_dragon_DRG-8D.json
+++ b/BT Advanced Custom Mechs/mech/mechdef_dragon_DRG-8D.json
@@ -48,6 +48,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 	  "unit_notsacellum"
     ],

--- a/BT Advanced Custom Mechs/mech/mechdef_enforcer_ENF-4AS.json
+++ b/BT Advanced Custom Mechs/mech/mechdef_enforcer_ENF-4AS.json
@@ -52,6 +52,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Custom Mechs/mech/mechdef_firestarter_FS9-J.json
+++ b/BT Advanced Custom Mechs/mech/mechdef_firestarter_FS9-J.json
@@ -37,6 +37,7 @@
 			"GraysGhosts",
 			"BroadswordLegion",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Custom Mechs/mech/mechdef_firestarter_FS9-P.json
+++ b/BT Advanced Custom Mechs/mech/mechdef_firestarter_FS9-P.json
@@ -37,6 +37,7 @@
 			"GraysGhosts",
 			"BroadswordLegion",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Custom Mechs/mech/mechdef_grasshopper_GHR-6J.json
+++ b/BT Advanced Custom Mechs/mech/mechdef_grasshopper_GHR-6J.json
@@ -36,6 +36,7 @@
 			"GraysGhosts",
 			"BroadswordLegion",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Custom Mechs/mech/mechdef_griffin_GRF-6CV.json
+++ b/BT Advanced Custom Mechs/mech/mechdef_griffin_GRF-6CV.json
@@ -38,6 +38,7 @@
 			"GraysGhosts",
 			"BroadswordLegion",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Custom Mechs/mech/mechdef_hollander_BZK-D2.json
+++ b/BT Advanced Custom Mechs/mech/mechdef_hollander_BZK-D2.json
@@ -38,6 +38,7 @@
 			"GraysGhosts",
 			"BroadswordLegion",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Custom Mechs/mech/mechdef_hollander_BZK-T100.json
+++ b/BT Advanced Custom Mechs/mech/mechdef_hollander_BZK-T100.json
@@ -38,6 +38,7 @@
 			"GraysGhosts",
 			"BroadswordLegion",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Custom Mechs/mech/mechdef_icarusii_ICR-1R.json
+++ b/BT Advanced Custom Mechs/mech/mechdef_icarusii_ICR-1R.json
@@ -37,6 +37,7 @@
 			"GraysGhosts",
 			"BroadswordLegion",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Custom Mechs/mech/mechdef_icarusii_ICR-2S.json
+++ b/BT Advanced Custom Mechs/mech/mechdef_icarusii_ICR-2S.json
@@ -37,6 +37,7 @@
 			"GraysGhosts",
 			"BroadswordLegion",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Custom Mechs/mech/mechdef_juggernaut_JG-R9X1.json
+++ b/BT Advanced Custom Mechs/mech/mechdef_juggernaut_JG-R9X1.json
@@ -36,6 +36,7 @@
 			"GraysGhosts",
 			"BroadswordLegion",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Custom Mechs/mech/mechdef_loaderking_LDR-K-1.json
+++ b/BT Advanced Custom Mechs/mech/mechdef_loaderking_LDR-K-1.json
@@ -36,6 +36,7 @@
 			"GraysGhosts",
 			"BroadswordLegion",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Custom Mechs/mech/mechdef_loaderking_LDR-K-2.json
+++ b/BT Advanced Custom Mechs/mech/mechdef_loaderking_LDR-K-2.json
@@ -36,6 +36,7 @@
 			"GraysGhosts",
 			"BroadswordLegion",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Custom Mechs/mech/mechdef_loaderking_LDR-K-3.json
+++ b/BT Advanced Custom Mechs/mech/mechdef_loaderking_LDR-K-3.json
@@ -36,6 +36,7 @@
 			"GraysGhosts",
 			"BroadswordLegion",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Custom Mechs/mech/mechdef_locust_LCT-4P.json
+++ b/BT Advanced Custom Mechs/mech/mechdef_locust_LCT-4P.json
@@ -36,6 +36,7 @@
 			"GraysGhosts",
 			"BroadswordLegion",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Custom Mechs/mech/mechdef_longbow_LGB-8Q.json
+++ b/BT Advanced Custom Mechs/mech/mechdef_longbow_LGB-8Q.json
@@ -35,6 +35,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 	  "unit_notsacellum"
     ],

--- a/BT Advanced Custom Mechs/mech/mechdef_mauler_MAL-2K.json
+++ b/BT Advanced Custom Mechs/mech/mechdef_mauler_MAL-2K.json
@@ -51,6 +51,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Custom Mechs/mech/mechdef_orion_ON1-R.json
+++ b/BT Advanced Custom Mechs/mech/mechdef_orion_ON1-R.json
@@ -50,6 +50,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 	  "unit_notsacellum"
     ],

--- a/BT Advanced Custom Mechs/mech/mechdef_ostroc_OSR-3J.json
+++ b/BT Advanced Custom Mechs/mech/mechdef_ostroc_OSR-3J.json
@@ -53,6 +53,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Custom Mechs/mech/mechdef_ostwar_OWR-2N.json
+++ b/BT Advanced Custom Mechs/mech/mechdef_ostwar_OWR-2N.json
@@ -51,6 +51,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Custom Mechs/mech/mechdef_ostwar_OWR-2Q.json
+++ b/BT Advanced Custom Mechs/mech/mechdef_ostwar_OWR-2Q.json
@@ -51,6 +51,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Custom Mechs/mech/mechdef_roughneck_RGH-2A.json
+++ b/BT Advanced Custom Mechs/mech/mechdef_roughneck_RGH-2A.json
@@ -44,6 +44,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Custom Mechs/mech/mechdef_shadowhawk_SHD-6S.json
+++ b/BT Advanced Custom Mechs/mech/mechdef_shadowhawk_SHD-6S.json
@@ -55,6 +55,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Custom Mechs/mech/mechdef_stinger_STG-4G.json
+++ b/BT Advanced Custom Mechs/mech/mechdef_stinger_STG-4G.json
@@ -45,6 +45,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Custom Mechs/mech/mechdef_thunderbolt_TDR-8SS.json
+++ b/BT Advanced Custom Mechs/mech/mechdef_thunderbolt_TDR-8SS.json
@@ -53,6 +53,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Custom Mechs/mech/mechdef_urbanmech_UM-R71.json
+++ b/BT Advanced Custom Mechs/mech/mechdef_urbanmech_UM-R71.json
@@ -47,6 +47,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Custom Mechs/mech/mechdef_victor_VTR-12R.json
+++ b/BT Advanced Custom Mechs/mech/mechdef_victor_VTR-12R.json
@@ -43,6 +43,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Custom Mechs/mech/mechdef_vindicator_VND-2AN.json
+++ b/BT Advanced Custom Mechs/mech/mechdef_vindicator_VND-2AN.json
@@ -48,6 +48,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Custom Mechs/mech/mechdef_wolfhound_WLF-4.json
+++ b/BT Advanced Custom Mechs/mech/mechdef_wolfhound_WLF-4.json
@@ -53,6 +53,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 	  "unit_notsacellum"
     ],

--- a/BT Advanced Mechs/mech/mechdef_atlas_AS7-K.json
+++ b/BT Advanced Mechs/mech/mechdef_atlas_AS7-K.json
@@ -40,6 +40,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_atlas_AS7-S.json
+++ b/BT Advanced Mechs/mech/mechdef_atlas_AS7-S.json
@@ -33,6 +33,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_atlas_AS7-S3.json
+++ b/BT Advanced Mechs/mech/mechdef_atlas_AS7-S3.json
@@ -29,6 +29,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_awesome_AWS-9Q.json
+++ b/BT Advanced Mechs/mech/mechdef_awesome_AWS-9Q.json
@@ -51,6 +51,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_banshee_BNC-5S.json
+++ b/BT Advanced Mechs/mech/mechdef_banshee_BNC-5S.json
@@ -27,6 +27,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_battlemaster_BLR-3M.json
+++ b/BT Advanced Mechs/mech/mechdef_battlemaster_BLR-3M.json
@@ -40,6 +40,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_battlemaster_BLR-4S.json
+++ b/BT Advanced Mechs/mech/mechdef_battlemaster_BLR-4S.json
@@ -27,6 +27,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_blackjack_BJ-2.json
+++ b/BT Advanced Mechs/mech/mechdef_blackjack_BJ-2.json
@@ -35,6 +35,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_blackjack_BJ-3.json
+++ b/BT Advanced Mechs/mech/mechdef_blackjack_BJ-3.json
@@ -38,6 +38,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_bombard_BMB-010.json
+++ b/BT Advanced Mechs/mech/mechdef_bombard_BMB-010.json
@@ -27,6 +27,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_bombard_BMB-013.json
+++ b/BT Advanced Mechs/mech/mechdef_bombard_BMB-013.json
@@ -27,6 +27,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_bushwacker_BWS-S2.json
+++ b/BT Advanced Mechs/mech/mechdef_bushwacker_BWS-S2.json
@@ -28,6 +28,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_bushwacker_BWS-X1.json
+++ b/BT Advanced Mechs/mech/mechdef_bushwacker_BWS-X1.json
@@ -28,6 +28,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_bushwacker_BWS-X2.json
+++ b/BT Advanced Mechs/mech/mechdef_bushwacker_BWS-X2.json
@@ -28,6 +28,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_catapult_CPLT-C4C.json
+++ b/BT Advanced Mechs/mech/mechdef_catapult_CPLT-C4C.json
@@ -35,6 +35,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_centurion_CN10-B.json
+++ b/BT Advanced Mechs/mech/mechdef_centurion_CN10-B.json
@@ -40,6 +40,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_centurion_CN9-D.json
+++ b/BT Advanced Mechs/mech/mechdef_centurion_CN9-D.json
@@ -39,6 +39,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_centurion_CN9-D3D.json
+++ b/BT Advanced Mechs/mech/mechdef_centurion_CN9-D3D.json
@@ -33,6 +33,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_champion_CHP-1N.json
+++ b/BT Advanced Mechs/mech/mechdef_champion_CHP-1N.json
@@ -34,6 +34,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_champion_CHP-1N2.json
+++ b/BT Advanced Mechs/mech/mechdef_champion_CHP-1N2.json
@@ -38,6 +38,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_champion_CHP-2N.json
+++ b/BT Advanced Mechs/mech/mechdef_champion_CHP-2N.json
@@ -38,6 +38,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_charger_CGR-1A1.json
+++ b/BT Advanced Mechs/mech/mechdef_charger_CGR-1A1.json
@@ -38,6 +38,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_charger_CGR-1A5.json
+++ b/BT Advanced Mechs/mech/mechdef_charger_CGR-1A5.json
@@ -35,6 +35,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_charger_CGR-1L.json
+++ b/BT Advanced Mechs/mech/mechdef_charger_CGR-1L.json
@@ -35,6 +35,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_charger_CGR-3K.json
+++ b/BT Advanced Mechs/mech/mechdef_charger_CGR-3K.json
@@ -32,6 +32,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_charger_CGR-SB.json
+++ b/BT Advanced Mechs/mech/mechdef_charger_CGR-SB.json
@@ -26,6 +26,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_cicada_CDA-3F.json
+++ b/BT Advanced Mechs/mech/mechdef_cicada_CDA-3F.json
@@ -40,6 +40,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_cicada_CDA-3G.json
+++ b/BT Advanced Mechs/mech/mechdef_cicada_CDA-3G.json
@@ -38,6 +38,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_cicada_CDA-3M.json
+++ b/BT Advanced Mechs/mech/mechdef_cicada_CDA-3M.json
@@ -39,6 +39,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_clint_CLNT-2-3T.json
+++ b/BT Advanced Mechs/mech/mechdef_clint_CLNT-2-3T.json
@@ -42,6 +42,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_clint_CLNT-2-3U.json
+++ b/BT Advanced Mechs/mech/mechdef_clint_CLNT-2-3U.json
@@ -39,6 +39,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_clint_CLNT-2-4T.json
+++ b/BT Advanced Mechs/mech/mechdef_clint_CLNT-2-4T.json
@@ -34,6 +34,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_clint_CLNT-5U.json
+++ b/BT Advanced Mechs/mech/mechdef_clint_CLNT-5U.json
@@ -30,6 +30,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_commando_COM-5S.json
+++ b/BT Advanced Mechs/mech/mechdef_commando_COM-5S.json
@@ -28,6 +28,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_corsair_COR-5R.json
+++ b/BT Advanced Mechs/mech/mechdef_corsair_COR-5R.json
@@ -31,6 +31,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_corsair_COR-5T.json
+++ b/BT Advanced Mechs/mech/mechdef_corsair_COR-5T.json
@@ -31,6 +31,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_corsair_COR-6R.json
+++ b/BT Advanced Mechs/mech/mechdef_corsair_COR-6R.json
@@ -31,6 +31,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_corsair_COR-7A.json
+++ b/BT Advanced Mechs/mech/mechdef_corsair_COR-7A.json
@@ -31,6 +31,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_corsair_COR-7R.json
+++ b/BT Advanced Mechs/mech/mechdef_corsair_COR-7R.json
@@ -31,6 +31,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_crusader_CRD-3R.json
+++ b/BT Advanced Mechs/mech/mechdef_crusader_CRD-3R.json
@@ -53,6 +53,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_crusader_CRD-4BR.json
+++ b/BT Advanced Mechs/mech/mechdef_crusader_CRD-4BR.json
@@ -27,6 +27,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_crusader_CRD-4K.json
+++ b/BT Advanced Mechs/mech/mechdef_crusader_CRD-4K.json
@@ -33,6 +33,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_crusader_CRD-5M.json
+++ b/BT Advanced Mechs/mech/mechdef_crusader_CRD-5M.json
@@ -39,6 +39,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_crusader_CRD-5S.json
+++ b/BT Advanced Mechs/mech/mechdef_crusader_CRD-5S.json
@@ -36,6 +36,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_dervish_DV-6M.json
+++ b/BT Advanced Mechs/mech/mechdef_dervish_DV-6M.json
@@ -54,6 +54,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_dervish_DV-7D.json
+++ b/BT Advanced Mechs/mech/mechdef_dervish_DV-7D.json
@@ -37,6 +37,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_dervish_DV-8D.json
+++ b/BT Advanced Mechs/mech/mechdef_dervish_DV-8D.json
@@ -30,6 +30,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_dragon_DRG-5N.json
+++ b/BT Advanced Mechs/mech/mechdef_dragon_DRG-5N.json
@@ -29,6 +29,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_emperor_EMP-5A.json
+++ b/BT Advanced Mechs/mech/mechdef_emperor_EMP-5A.json
@@ -34,6 +34,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_emperor_EMP-6A.json
+++ b/BT Advanced Mechs/mech/mechdef_emperor_EMP-6A.json
@@ -41,6 +41,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_enforcer_ENF-5D.json
+++ b/BT Advanced Mechs/mech/mechdef_enforcer_ENF-5D.json
@@ -28,6 +28,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_enforceriii_ENF-6G.json
+++ b/BT Advanced Mechs/mech/mechdef_enforceriii_ENF-6G.json
@@ -28,6 +28,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_enforceriii_ENF-6M.json
+++ b/BT Advanced Mechs/mech/mechdef_enforceriii_ENF-6M.json
@@ -28,6 +28,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_firestarter_FS9-S.json
+++ b/BT Advanced Mechs/mech/mechdef_firestarter_FS9-S.json
@@ -53,6 +53,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_firestarter_FS9-S1.json
+++ b/BT Advanced Mechs/mech/mechdef_firestarter_FS9-S1.json
@@ -53,6 +53,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_grasshopper_GHR-5J.json
+++ b/BT Advanced Mechs/mech/mechdef_grasshopper_GHR-5J.json
@@ -52,6 +52,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_grasshopper_GHR-5N.json
+++ b/BT Advanced Mechs/mech/mechdef_grasshopper_GHR-5N.json
@@ -52,6 +52,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_grasshopper_GHR-C.json
+++ b/BT Advanced Mechs/mech/mechdef_grasshopper_GHR-C.json
@@ -39,6 +39,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_griffin_GRF-1DS.json
+++ b/BT Advanced Mechs/mech/mechdef_griffin_GRF-1DS.json
@@ -40,6 +40,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_griffin_GRF-3M.json
+++ b/BT Advanced Mechs/mech/mechdef_griffin_GRF-3M.json
@@ -41,6 +41,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_hatamotochi_HTM-27T.json
+++ b/BT Advanced Mechs/mech/mechdef_hatamotochi_HTM-27T.json
@@ -27,6 +27,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_hellspawn_HSN-7D.json
+++ b/BT Advanced Mechs/mech/mechdef_hellspawn_HSN-7D.json
@@ -30,6 +30,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_highlander_HGN-732.json
+++ b/BT Advanced Mechs/mech/mechdef_highlander_HGN-732.json
@@ -30,6 +30,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_highlander_HGN-734.json
+++ b/BT Advanced Mechs/mech/mechdef_highlander_HGN-734.json
@@ -27,6 +27,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_hollander_BZK-F3.json
+++ b/BT Advanced Mechs/mech/mechdef_hollander_BZK-F3.json
@@ -32,6 +32,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_hollander_BZK-G1.json
+++ b/BT Advanced Mechs/mech/mechdef_hollander_BZK-G1.json
@@ -32,6 +32,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_hollanderii_BZK-F5.json
+++ b/BT Advanced Mechs/mech/mechdef_hollanderii_BZK-F5.json
@@ -32,6 +32,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_hollanderii_BZK-F7.json
+++ b/BT Advanced Mechs/mech/mechdef_hollanderii_BZK-F7.json
@@ -32,6 +32,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_hunchback_HBK-5M.json
+++ b/BT Advanced Mechs/mech/mechdef_hunchback_HBK-5M.json
@@ -37,6 +37,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_hunchback_HBK-5N.json
+++ b/BT Advanced Mechs/mech/mechdef_hunchback_HBK-5N.json
@@ -37,6 +37,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_hunchback_HBK-5S.json
+++ b/BT Advanced Mechs/mech/mechdef_hunchback_HBK-5S.json
@@ -28,6 +28,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_hunchback_HBK-6N.json
+++ b/BT Advanced Mechs/mech/mechdef_hunchback_HBK-6N.json
@@ -34,6 +34,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_huronw_HUR-WO-R4L.json
+++ b/BT Advanced Mechs/mech/mechdef_huronw_HUR-WO-R4L.json
@@ -35,6 +35,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_jagermech_JM6-DD.json
+++ b/BT Advanced Mechs/mech/mechdef_jagermech_JM6-DD.json
@@ -29,6 +29,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_jagermech_JM6-DG.json
+++ b/BT Advanced Mechs/mech/mechdef_jagermech_JM6-DG.json
@@ -29,6 +29,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_jagermech_JM6-DGr.json
+++ b/BT Advanced Mechs/mech/mechdef_jagermech_JM6-DGr.json
@@ -29,6 +29,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_jagermechii_JM7-D.json
+++ b/BT Advanced Mechs/mech/mechdef_jagermechii_JM7-D.json
@@ -27,6 +27,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_jagermechiii_JM6-D3.json
+++ b/BT Advanced Mechs/mech/mechdef_jagermechiii_JM6-D3.json
@@ -29,6 +29,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_jenner_JR7-C.json
+++ b/BT Advanced Mechs/mech/mechdef_jenner_JR7-C.json
@@ -32,6 +32,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_jenner_JR7-K.json
+++ b/BT Advanced Mechs/mech/mechdef_jenner_JR7-K.json
@@ -34,6 +34,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_juggernaut_JG-R9T1.json
+++ b/BT Advanced Mechs/mech/mechdef_juggernaut_JG-R9T1.json
@@ -28,6 +28,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_juggernaut_JG-R9T2.json
+++ b/BT Advanced Mechs/mech/mechdef_juggernaut_JG-R9T2.json
@@ -28,6 +28,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_juggernaut_JG-R9T3.json
+++ b/BT Advanced Mechs/mech/mechdef_juggernaut_JG-R9T3.json
@@ -28,6 +28,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_kingcrab_KGC-001.json
+++ b/BT Advanced Mechs/mech/mechdef_kingcrab_KGC-001.json
@@ -39,6 +39,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_kintaro_KTO-20.json
+++ b/BT Advanced Mechs/mech/mechdef_kintaro_KTO-20.json
@@ -31,6 +31,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_locust_LCT-3D.json
+++ b/BT Advanced Mechs/mech/mechdef_locust_LCT-3D.json
@@ -28,6 +28,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_locust_LCT-3M.json
+++ b/BT Advanced Mechs/mech/mechdef_locust_LCT-3M.json
@@ -39,6 +39,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_locust_LCT-3S.json
+++ b/BT Advanced Mechs/mech/mechdef_locust_LCT-3S.json
@@ -27,6 +27,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_longbow_LGB-0W.json
+++ b/BT Advanced Mechs/mech/mechdef_longbow_LGB-0W.json
@@ -52,6 +52,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_longbow_LGB-12C.json
+++ b/BT Advanced Mechs/mech/mechdef_longbow_LGB-12C.json
@@ -37,6 +37,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_longbow_LGB-7Q.json
+++ b/BT Advanced Mechs/mech/mechdef_longbow_LGB-7Q.json
@@ -52,6 +52,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_longbow_LGB-7V.json
+++ b/BT Advanced Mechs/mech/mechdef_longbow_LGB-7V.json
@@ -40,6 +40,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_mackie-7A.json
+++ b/BT Advanced Mechs/mech/mechdef_mackie-7A.json
@@ -31,6 +31,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_mackie-8B.json
+++ b/BT Advanced Mechs/mech/mechdef_mackie-8B.json
@@ -31,6 +31,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_marauderII_MAD-4A.json
+++ b/BT Advanced Mechs/mech/mechdef_marauderII_MAD-4A.json
@@ -26,6 +26,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_marauderII_MAD-4B.json
+++ b/BT Advanced Mechs/mech/mechdef_marauderII_MAD-4B.json
@@ -26,6 +26,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_marauderII_MAD-5A.json
+++ b/BT Advanced Mechs/mech/mechdef_marauderII_MAD-5A.json
@@ -27,6 +27,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_marauderII_MAD-5B.json
+++ b/BT Advanced Mechs/mech/mechdef_marauderII_MAD-5B.json
@@ -27,6 +27,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_marauderII_MAD-5C.json
+++ b/BT Advanced Mechs/mech/mechdef_marauderII_MAD-5C.json
@@ -27,6 +27,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_marauder_MAD-3M.json
+++ b/BT Advanced Mechs/mech/mechdef_marauder_MAD-3M.json
@@ -34,6 +34,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_marauder_MAD-5D.json
+++ b/BT Advanced Mechs/mech/mechdef_marauder_MAD-5D.json
@@ -31,6 +31,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_marauder_MAD-5M.json
+++ b/BT Advanced Mechs/mech/mechdef_marauder_MAD-5M.json
@@ -40,6 +40,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_marauder_MAD-5S.json
+++ b/BT Advanced Mechs/mech/mechdef_marauder_MAD-5S.json
@@ -28,6 +28,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_mauler_MAL-2R.json
+++ b/BT Advanced Mechs/mech/mechdef_mauler_MAL-2R.json
@@ -28,6 +28,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_mongoose_MON-67.json
+++ b/BT Advanced Mechs/mech/mechdef_mongoose_MON-67.json
@@ -52,6 +52,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_nightstar_NSR-9FC.json
+++ b/BT Advanced Mechs/mech/mechdef_nightstar_NSR-9FC.json
@@ -27,6 +27,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_nightstar_NSR-9J.json
+++ b/BT Advanced Mechs/mech/mechdef_nightstar_NSR-9J.json
@@ -28,6 +28,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_orion_ON1-M.json
+++ b/BT Advanced Mechs/mech/mechdef_orion_ON1-M.json
@@ -41,6 +41,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_orion_ON1-MA.json
+++ b/BT Advanced Mechs/mech/mechdef_orion_ON1-MA.json
@@ -39,6 +39,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_orion_ON1-MB.json
+++ b/BT Advanced Mechs/mech/mechdef_orion_ON1-MB.json
@@ -36,6 +36,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_orion_ON1-MC.json
+++ b/BT Advanced Mechs/mech/mechdef_orion_ON1-MC.json
@@ -32,6 +32,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_orion_ON1-MD.json
+++ b/BT Advanced Mechs/mech/mechdef_orion_ON1-MD.json
@@ -32,6 +32,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_osiris_OSR-3D.json
+++ b/BT Advanced Mechs/mech/mechdef_osiris_OSR-3D.json
@@ -28,6 +28,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_ostroc_OSR-2C.json
+++ b/BT Advanced Mechs/mech/mechdef_ostroc_OSR-2C.json
@@ -54,6 +54,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_ostroc_OSR-2D.json
+++ b/BT Advanced Mechs/mech/mechdef_ostroc_OSR-2D.json
@@ -53,6 +53,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_ostroc_OSR-2L.json
+++ b/BT Advanced Mechs/mech/mechdef_ostroc_OSR-2L.json
@@ -40,6 +40,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_ostroc_OSR-3C.json
+++ b/BT Advanced Mechs/mech/mechdef_ostroc_OSR-3C.json
@@ -42,6 +42,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_ostsol_OTL-4D.json
+++ b/BT Advanced Mechs/mech/mechdef_ostsol_OTL-4D.json
@@ -53,6 +53,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_ostsol_OTL-5M.json
+++ b/BT Advanced Mechs/mech/mechdef_ostsol_OTL-5M.json
@@ -32,6 +32,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_panther_PNT-10K.json
+++ b/BT Advanced Mechs/mech/mechdef_panther_PNT-10K.json
@@ -28,6 +28,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_panther_PNT-10KA.json
+++ b/BT Advanced Mechs/mech/mechdef_panther_PNT-10KA.json
@@ -28,6 +28,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_panther_PNT-C.json
+++ b/BT Advanced Mechs/mech/mechdef_panther_PNT-C.json
@@ -28,6 +28,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_panther_PNT-CA.json
+++ b/BT Advanced Mechs/mech/mechdef_panther_PNT-CA.json
@@ -28,6 +28,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_phoenixhawk_PHX-HK2.json
+++ b/BT Advanced Mechs/mech/mechdef_phoenixhawk_PHX-HK2.json
@@ -40,6 +40,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_quickdraw_QKD-5K.json
+++ b/BT Advanced Mechs/mech/mechdef_quickdraw_QKD-5K.json
@@ -30,6 +30,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_quickdraw_QKD-C.json
+++ b/BT Advanced Mechs/mech/mechdef_quickdraw_QKD-C.json
@@ -29,6 +29,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_rakshasa_MDG-1A.json
+++ b/BT Advanced Mechs/mech/mechdef_rakshasa_MDG-1A.json
@@ -28,6 +28,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_rakshasa_MDG-1B.json
+++ b/BT Advanced Mechs/mech/mechdef_rakshasa_MDG-1B.json
@@ -28,6 +28,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_roughneck_RGH-1A.json
+++ b/BT Advanced Mechs/mech/mechdef_roughneck_RGH-1A.json
@@ -32,6 +32,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_roughneck_RGH-1B.json
+++ b/BT Advanced Mechs/mech/mechdef_roughneck_RGH-1B.json
@@ -32,6 +32,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_roughneck_RGH-1C.json
+++ b/BT Advanced Mechs/mech/mechdef_roughneck_RGH-1C.json
@@ -32,6 +32,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_roughneck_RGH-3A.json
+++ b/BT Advanced Mechs/mech/mechdef_roughneck_RGH-3A.json
@@ -32,6 +32,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_shadowhawk_SHD-5M.json
+++ b/BT Advanced Mechs/mech/mechdef_shadowhawk_SHD-5M.json
@@ -43,6 +43,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_spider_SDR-7M.json
+++ b/BT Advanced Mechs/mech/mechdef_spider_SDR-7M.json
@@ -39,6 +39,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_spider_SDR-8M.json
+++ b/BT Advanced Mechs/mech/mechdef_spider_SDR-8M.json
@@ -30,6 +30,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_spider_SDR-C.json
+++ b/BT Advanced Mechs/mech/mechdef_spider_SDR-C.json
@@ -39,6 +39,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_stalker_STK-5M.json
+++ b/BT Advanced Mechs/mech/mechdef_stalker_STK-5M.json
@@ -41,6 +41,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_stalker_STK-6M.json
+++ b/BT Advanced Mechs/mech/mechdef_stalker_STK-6M.json
@@ -30,6 +30,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_stinger_STG-3G.json
+++ b/BT Advanced Mechs/mech/mechdef_stinger_STG-3G.json
@@ -51,6 +51,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_stinger_STG-3R.json
+++ b/BT Advanced Mechs/mech/mechdef_stinger_STG-3R.json
@@ -51,6 +51,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_stinger_STG-5M.json
+++ b/BT Advanced Mechs/mech/mechdef_stinger_STG-5M.json
@@ -40,6 +40,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_stinger_STG-A5.json
+++ b/BT Advanced Mechs/mech/mechdef_stinger_STG-A5.json
@@ -38,6 +38,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_talos_TLS-1B.json
+++ b/BT Advanced Mechs/mech/mechdef_talos_TLS-1B.json
@@ -33,6 +33,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_thanatos_TNS-4S.json
+++ b/BT Advanced Mechs/mech/mechdef_thanatos_TNS-4S.json
@@ -26,6 +26,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_thanatos_TNS-4T.json
+++ b/BT Advanced Mechs/mech/mechdef_thanatos_TNS-4T.json
@@ -27,6 +27,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_thunderbolt_TDR-7M.json
+++ b/BT Advanced Mechs/mech/mechdef_thunderbolt_TDR-7M.json
@@ -39,6 +39,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_thunderbolt_TDR-9S.json
+++ b/BT Advanced Mechs/mech/mechdef_thunderbolt_TDR-9S.json
@@ -27,6 +27,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_thunderbolt_TDR-9SE.json
+++ b/BT Advanced Mechs/mech/mechdef_thunderbolt_TDR-9SE.json
@@ -29,6 +29,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_trebuchet_TBT-3C.json
+++ b/BT Advanced Mechs/mech/mechdef_trebuchet_TBT-3C.json
@@ -31,6 +31,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_trebuchet_TBT-7M.json
+++ b/BT Advanced Mechs/mech/mechdef_trebuchet_TBT-7M.json
@@ -41,6 +41,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_urbanmech_UM-R63.json
+++ b/BT Advanced Mechs/mech/mechdef_urbanmech_UM-R63.json
@@ -34,6 +34,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_uziel_UZL-2S.json
+++ b/BT Advanced Mechs/mech/mechdef_uziel_UZL-2S.json
@@ -29,6 +29,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_valkyrie_VLK-QA.json
+++ b/BT Advanced Mechs/mech/mechdef_valkyrie_VLK-QA.json
@@ -31,6 +31,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_valkyrie_VLK-QD.json
+++ b/BT Advanced Mechs/mech/mechdef_valkyrie_VLK-QD.json
@@ -30,6 +30,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_valkyrie_VLK-QF.json
+++ b/BT Advanced Mechs/mech/mechdef_valkyrie_VLK-QF.json
@@ -28,6 +28,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_victor_VTR-9K.json
+++ b/BT Advanced Mechs/mech/mechdef_victor_VTR-9K.json
@@ -38,6 +38,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_victor_VTR-C.json
+++ b/BT Advanced Mechs/mech/mechdef_victor_VTR-C.json
@@ -33,6 +33,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_vindicator_VND-3L.json
+++ b/BT Advanced Mechs/mech/mechdef_vindicator_VND-3L.json
@@ -33,6 +33,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_warhammer_WHM-7M.json
+++ b/BT Advanced Mechs/mech/mechdef_warhammer_WHM-7M.json
@@ -42,6 +42,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_warhammer_WHM-7S.json
+++ b/BT Advanced Mechs/mech/mechdef_warhammer_WHM-7S.json
@@ -26,6 +26,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_wasp_WSP-105.json
+++ b/BT Advanced Mechs/mech/mechdef_wasp_WSP-105.json
@@ -40,6 +40,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_wasp_WSP-1A.json
+++ b/BT Advanced Mechs/mech/mechdef_wasp_WSP-1A.json
@@ -52,6 +52,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_wasp_WSP-1S.json
+++ b/BT Advanced Mechs/mech/mechdef_wasp_WSP-1S.json
@@ -28,6 +28,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_wasp_WSP-1W.json
+++ b/BT Advanced Mechs/mech/mechdef_wasp_WSP-1W.json
@@ -26,6 +26,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_wasp_WSP-3M.json
+++ b/BT Advanced Mechs/mech/mechdef_wasp_WSP-3M.json
@@ -37,6 +37,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_wasp_WSP-3W.json
+++ b/BT Advanced Mechs/mech/mechdef_wasp_WSP-3W.json
@@ -26,6 +26,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_wolfhound_WLF-1.json
+++ b/BT Advanced Mechs/mech/mechdef_wolfhound_WLF-1.json
@@ -30,6 +30,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_wolfhound_WLF-1A.json
+++ b/BT Advanced Mechs/mech/mechdef_wolfhound_WLF-1A.json
@@ -28,6 +28,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_wolfhound_WLF-1B.json
+++ b/BT Advanced Mechs/mech/mechdef_wolfhound_WLF-1B.json
@@ -28,6 +28,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_wolfhound_WLF-2.json
+++ b/BT Advanced Mechs/mech/mechdef_wolfhound_WLF-2.json
@@ -29,6 +29,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_wolverine_WVR-7K.json
+++ b/BT Advanced Mechs/mech/mechdef_wolverine_WVR-7K.json
@@ -30,6 +30,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_wolverine_WVR-7M.json
+++ b/BT Advanced Mechs/mech/mechdef_wolverine_WVR-7M.json
@@ -37,6 +37,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_zeus_ZEU-9S.json
+++ b/BT Advanced Mechs/mech/mechdef_zeus_ZEU-9S.json
@@ -30,6 +30,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_zeus_ZEU-9S2.json
+++ b/BT Advanced Mechs/mech/mechdef_zeus_ZEU-9S2.json
@@ -26,6 +26,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/BT Advanced Mechs/mech/mechdef_zeus_ZEU-9T.json
+++ b/BT Advanced Mechs/mech/mechdef_zeus_ZEU-9T.json
@@ -26,6 +26,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Flashpoint Unit Module/mech/mechdef_axman_AXM-1N.json
+++ b/Flashpoint Unit Module/mech/mechdef_axman_AXM-1N.json
@@ -28,6 +28,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Flashpoint Unit Module/mech/mechdef_axman_AXM-1TL.json
+++ b/Flashpoint Unit Module/mech/mechdef_axman_AXM-1TL.json
@@ -28,6 +28,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Flashpoint Unit Module/mech/mechdef_axman_AXM-3N.json
+++ b/Flashpoint Unit Module/mech/mechdef_axman_AXM-3N.json
@@ -29,6 +29,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Flashpoint Unit Module/mech/mechdef_axman_AXM-3S.json
+++ b/Flashpoint Unit Module/mech/mechdef_axman_AXM-3S.json
@@ -28,6 +28,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Flashpoint Unit Module/mech/mechdef_cyclops_CP-10-Z.json
+++ b/Flashpoint Unit Module/mech/mechdef_cyclops_CP-10-Z.json
@@ -53,6 +53,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Flashpoint Unit Module/mech/mechdef_cyclops_CP-11-A.json
+++ b/Flashpoint Unit Module/mech/mechdef_cyclops_CP-11-A.json
@@ -43,6 +43,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Flashpoint Unit Module/mech/mechdef_cyclops_CP-11-G.json
+++ b/Flashpoint Unit Module/mech/mechdef_cyclops_CP-11-G.json
@@ -27,6 +27,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Flashpoint Unit Module/mech/mechdef_cyclops_CP-12-K.json
+++ b/Flashpoint Unit Module/mech/mechdef_cyclops_CP-12-K.json
@@ -28,6 +28,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Flashpoint Unit Module/mech/mechdef_hatchetman_HCT-3F.json
+++ b/Flashpoint Unit Module/mech/mechdef_hatchetman_HCT-3F.json
@@ -36,6 +36,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Flashpoint Unit Module/mech/mechdef_hatchetman_HCT-5D.json
+++ b/Flashpoint Unit Module/mech/mechdef_hatchetman_HCT-5D.json
@@ -28,6 +28,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Flashpoint Unit Module/mech/mechdef_hatchetman_HCT-5S.json
+++ b/Flashpoint Unit Module/mech/mechdef_hatchetman_HCT-5S.json
@@ -28,6 +28,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Flashpoint Unit Module/mech/mechdef_hatchetman_HCT-6D.json
+++ b/Flashpoint Unit Module/mech/mechdef_hatchetman_HCT-6D.json
@@ -28,6 +28,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Heavy Metal Unit Module/mech/mechdef_annihilator_ANH-1A.json
+++ b/Heavy Metal Unit Module/mech/mechdef_annihilator_ANH-1A.json
@@ -26,6 +26,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Heavy Metal Unit Module/mech/mechdef_annihilator_ANH-1E.json
+++ b/Heavy Metal Unit Module/mech/mechdef_annihilator_ANH-1E.json
@@ -26,6 +26,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Heavy Metal Unit Module/mech/mechdef_annihilator_ANH-1G.json
+++ b/Heavy Metal Unit Module/mech/mechdef_annihilator_ANH-1G.json
@@ -27,6 +27,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Heavy Metal Unit Module/mech/mechdef_annihilator_ANH-1X.json
+++ b/Heavy Metal Unit Module/mech/mechdef_annihilator_ANH-1X.json
@@ -25,6 +25,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Heavy Metal Unit Module/mech/mechdef_annihilator_ANH-2A.json
+++ b/Heavy Metal Unit Module/mech/mechdef_annihilator_ANH-2A.json
@@ -26,6 +26,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Heavy Metal Unit Module/mech/mechdef_archer_ARC-2R.json
+++ b/Heavy Metal Unit Module/mech/mechdef_archer_ARC-2R.json
@@ -52,6 +52,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Heavy Metal Unit Module/mech/mechdef_archer_ARC-2W.json
+++ b/Heavy Metal Unit Module/mech/mechdef_archer_ARC-2W.json
@@ -27,6 +27,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Heavy Metal Unit Module/mech/mechdef_archer_ARC-4M.json
+++ b/Heavy Metal Unit Module/mech/mechdef_archer_ARC-4M.json
@@ -40,6 +40,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Heavy Metal Unit Module/mech/mechdef_archer_ARC-5R.json
+++ b/Heavy Metal Unit Module/mech/mechdef_archer_ARC-5R.json
@@ -28,6 +28,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Heavy Metal Unit Module/mech/mechdef_archer_ARC-5W.json
+++ b/Heavy Metal Unit Module/mech/mechdef_archer_ARC-5W.json
@@ -27,6 +27,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Heavy Metal Unit Module/mech/mechdef_archer_ARC-6Q.json
+++ b/Heavy Metal Unit Module/mech/mechdef_archer_ARC-6Q.json
@@ -26,6 +26,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Heavy Metal Unit Module/mech/mechdef_assassin_ASN-21.json
+++ b/Heavy Metal Unit Module/mech/mechdef_assassin_ASN-21.json
@@ -43,6 +43,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Heavy Metal Unit Module/mech/mechdef_assassin_ASN-23.json
+++ b/Heavy Metal Unit Module/mech/mechdef_assassin_ASN-23.json
@@ -40,6 +40,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Heavy Metal Unit Module/mech/mechdef_assassin_ASN-SB.json
+++ b/Heavy Metal Unit Module/mech/mechdef_assassin_ASN-SB.json
@@ -27,6 +27,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Heavy Metal Unit Module/mech/mechdef_bullshark_BSK-M3.json
+++ b/Heavy Metal Unit Module/mech/mechdef_bullshark_BSK-M3.json
@@ -568,6 +568,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Heavy Metal Unit Module/mech/mechdef_flea_FLE-15.json
+++ b/Heavy Metal Unit Module/mech/mechdef_flea_FLE-15.json
@@ -30,6 +30,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Heavy Metal Unit Module/mech/mechdef_flea_FLE-16.json
+++ b/Heavy Metal Unit Module/mech/mechdef_flea_FLE-16.json
@@ -26,6 +26,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Heavy Metal Unit Module/mech/mechdef_flea_FLE-17.json
+++ b/Heavy Metal Unit Module/mech/mechdef_flea_FLE-17.json
@@ -41,6 +41,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Heavy Metal Unit Module/mech/mechdef_phoenixhawk_PXH-1.json
+++ b/Heavy Metal Unit Module/mech/mechdef_phoenixhawk_PXH-1.json
@@ -53,6 +53,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Heavy Metal Unit Module/mech/mechdef_phoenixhawk_PXH-1D.json
+++ b/Heavy Metal Unit Module/mech/mechdef_phoenixhawk_PXH-1D.json
@@ -31,6 +31,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Heavy Metal Unit Module/mech/mechdef_phoenixhawk_PXH-3D.json
+++ b/Heavy Metal Unit Module/mech/mechdef_phoenixhawk_PXH-3D.json
@@ -29,6 +29,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Heavy Metal Unit Module/mech/mechdef_phoenixhawk_PXH-3M.json
+++ b/Heavy Metal Unit Module/mech/mechdef_phoenixhawk_PXH-3M.json
@@ -40,6 +40,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Heavy Metal Unit Module/mech/mechdef_phoenixhawk_PXH-3S.json
+++ b/Heavy Metal Unit Module/mech/mechdef_phoenixhawk_PXH-3S.json
@@ -29,6 +29,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Heavy Metal Unit Module/mech/mechdef_rifleman_RFL-3N.json
+++ b/Heavy Metal Unit Module/mech/mechdef_rifleman_RFL-3N.json
@@ -51,6 +51,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Heavy Metal Unit Module/mech/mechdef_rifleman_RFL-4D.json
+++ b/Heavy Metal Unit Module/mech/mechdef_rifleman_RFL-4D.json
@@ -27,6 +27,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Heavy Metal Unit Module/mech/mechdef_rifleman_RFL-5D.json
+++ b/Heavy Metal Unit Module/mech/mechdef_rifleman_RFL-5D.json
@@ -27,6 +27,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Heavy Metal Unit Module/mech/mechdef_rifleman_RFL-5M.json
+++ b/Heavy Metal Unit Module/mech/mechdef_rifleman_RFL-5M.json
@@ -39,6 +39,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Heavy Metal Unit Module/mech/mechdef_vulcan_VL-2T.json
+++ b/Heavy Metal Unit Module/mech/mechdef_vulcan_VL-2T.json
@@ -53,6 +53,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Heavy Metal Unit Module/mech/mechdef_vulcan_VL-5T.json
+++ b/Heavy Metal Unit Module/mech/mechdef_vulcan_VL-5T.json
@@ -53,6 +53,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Heavy Metal Unit Module/mech/mechdef_vulcan_VT-5M.json
+++ b/Heavy Metal Unit Module/mech/mechdef_vulcan_VT-5M.json
@@ -33,6 +33,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Heavy Metal Unit Module/mech/mechdef_vulcan_VT-5S.json
+++ b/Heavy Metal Unit Module/mech/mechdef_vulcan_VT-5S.json
@@ -29,6 +29,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/JK_VariantsCampaign/mech/mechdef_atlas_AS7-RS.json
+++ b/JK_VariantsCampaign/mech/mechdef_atlas_AS7-RS.json
@@ -54,6 +54,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/JK_VariantsCampaign/mech/mechdef_commando_COM-3A.json
+++ b/JK_VariantsCampaign/mech/mechdef_commando_COM-3A.json
@@ -28,6 +28,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/JK_VariantsCampaign/mech/mechdef_hunchback_HBK-4H.json
+++ b/JK_VariantsCampaign/mech/mechdef_hunchback_HBK-4H.json
@@ -53,6 +53,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/JK_VariantsCampaign/mech/mechdef_hunchback_HBK-4J.json
+++ b/JK_VariantsCampaign/mech/mechdef_hunchback_HBK-4J.json
@@ -54,6 +54,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/JK_VariantsCampaign/mech/mechdef_hunchback_HBK-4N.json
+++ b/JK_VariantsCampaign/mech/mechdef_hunchback_HBK-4N.json
@@ -54,6 +54,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/JK_VariantsCampaign/mech/mechdef_hunchback_HBK-4SP.json
+++ b/JK_VariantsCampaign/mech/mechdef_hunchback_HBK-4SP.json
@@ -53,6 +53,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/JK_VariantsCampaign/mech/mechdef_locust_LCT-3V.json
+++ b/JK_VariantsCampaign/mech/mechdef_locust_LCT-3V.json
@@ -53,6 +53,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/JK_VariantsCampaign/mech/mechdef_quickdraw_QKD-4H.json
+++ b/JK_VariantsCampaign/mech/mechdef_quickdraw_QKD-4H.json
@@ -55,6 +55,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
     ],

--- a/JK_VariantsCampaign/mech/mechdef_shadowhawk_SHD-2K.json
+++ b/JK_VariantsCampaign/mech/mechdef_shadowhawk_SHD-2K.json
@@ -30,6 +30,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/JK_VariantsCampaign/mech/mechdef_stalker_STK-3H.json
+++ b/JK_VariantsCampaign/mech/mechdef_stalker_STK-3H.json
@@ -54,6 +54,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
     ],

--- a/JK_VariantsCampaign/mech/mechdef_stalker_STK-4N.json
+++ b/JK_VariantsCampaign/mech/mechdef_stalker_STK-4N.json
@@ -54,6 +54,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
     ],

--- a/JK_VariantsCampaign/mech/mechdef_stalker_STK-4P.json
+++ b/JK_VariantsCampaign/mech/mechdef_stalker_STK-4P.json
@@ -52,6 +52,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
     ],

--- a/JK_VariantsCampaign/mech/mechdef_trebuchet_TBT-5S.json
+++ b/JK_VariantsCampaign/mech/mechdef_trebuchet_TBT-5S.json
@@ -53,6 +53,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/JK_VariantsCampaign/mech/mechdef_victor_VTR-9A1.json
+++ b/JK_VariantsCampaign/mech/mechdef_victor_VTR-9A1.json
@@ -54,6 +54,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_atlas_AS7-A.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_atlas_AS7-A.json
@@ -53,6 +53,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_atlas_AS7-D.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_atlas_AS7-D.json
@@ -53,6 +53,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_awesome_AWS-8Q.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_awesome_AWS-8Q.json
@@ -53,6 +53,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_awesome_AWS-8T.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_awesome_AWS-8T.json
@@ -41,6 +41,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_banshee_BNC-3E.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_banshee_BNC-3E.json
@@ -53,6 +53,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_banshee_BNC-3S.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_banshee_BNC-3S.json
@@ -41,6 +41,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_battlemaster_BLR-1G.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_battlemaster_BLR-1G.json
@@ -53,6 +53,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_blackjack_BJ-1.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_blackjack_BJ-1.json
@@ -54,6 +54,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
     ],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_catapult_CPLT-C1.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_catapult_CPLT-C1.json
@@ -54,6 +54,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_cicada_CDA-2A.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_cicada_CDA-2A.json
@@ -53,6 +53,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_commando_COM-2D.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_commando_COM-2D.json
@@ -35,6 +35,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_enforcer_ENF-4R.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_enforcer_ENF-4R.json
@@ -42,6 +42,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_firestarter_FS9-H.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_firestarter_FS9-H.json
@@ -56,6 +56,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_grasshopper_GHR-5H.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_grasshopper_GHR-5H.json
@@ -54,6 +54,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_griffin_GRF-1N.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_griffin_GRF-1N.json
@@ -57,6 +57,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_griffin_GRF-1S.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_griffin_GRF-1S.json
@@ -30,6 +30,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_hunchback_HBK-4G.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_hunchback_HBK-4G.json
@@ -54,6 +54,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_hunchback_HBK-4P.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_hunchback_HBK-4P.json
@@ -54,6 +54,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_jagermech_JM6-S.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_jagermech_JM6-S.json
@@ -53,6 +53,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
     ],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_jenner_JR7-D.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_jenner_JR7-D.json
@@ -56,6 +56,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
     ],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_kintaro_KTO-18.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_kintaro_KTO-18.json
@@ -32,6 +32,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_locust_LCT-1E.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_locust_LCT-1E.json
@@ -53,6 +53,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_locust_LCT-1S.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_locust_LCT-1S.json
@@ -28,6 +28,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_locust_LCT-1V.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_locust_LCT-1V.json
@@ -51,6 +51,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_marauder_MAD-3R.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_marauder_MAD-3R.json
@@ -51,6 +51,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_orion_ON1-K.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_orion_ON1-K.json
@@ -53,6 +53,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
     ],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_quickdraw_QKD-4G.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_quickdraw_QKD-4G.json
@@ -56,6 +56,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
     ],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_quickdraw_QKD-5A.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_quickdraw_QKD-5A.json
@@ -56,6 +56,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
     ],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_shadowhawk_SHD-2H.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_shadowhawk_SHD-2H.json
@@ -56,6 +56,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_spider_SDR-5V.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_spider_SDR-5V.json
@@ -54,6 +54,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_stalker_STK-3F.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_stalker_STK-3F.json
@@ -54,6 +54,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
     ],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_thunderbolt_TDR-5S.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_thunderbolt_TDR-5S.json
@@ -52,6 +52,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_thunderbolt_TDR-5SE.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_thunderbolt_TDR-5SE.json
@@ -30,6 +30,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_thunderbolt_TDR-5SS.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_thunderbolt_TDR-5SS.json
@@ -29,6 +29,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_trebuchet_TBT-5N.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_trebuchet_TBT-5N.json
@@ -55,6 +55,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_urbanmech_UM-R60.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_urbanmech_UM-R60.json
@@ -53,6 +53,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_urbanmech_UM-R60L.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_urbanmech_UM-R60L.json
@@ -38,6 +38,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_urbanmech_UM-R90.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_urbanmech_UM-R90.json
@@ -56,6 +56,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_victor_VTR-9B.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_victor_VTR-9B.json
@@ -55,6 +55,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_vindicator_VND-1R.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_vindicator_VND-1R.json
@@ -37,6 +37,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_warhammer_WHM-6R.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_warhammer_WHM-6R.json
@@ -52,6 +52,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/MechEngineer Vanilla Mechs/mech/mechdef_zeus_ZEU-6S.json
+++ b/MechEngineer Vanilla Mechs/mech/mechdef_zeus_ZEU-6S.json
@@ -51,6 +51,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Urban Warfare Unit Module/mech/mechdef_javelin_JVN-10A.json
+++ b/Urban Warfare Unit Module/mech/mechdef_javelin_JVN-10A.json
@@ -30,6 +30,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Urban Warfare Unit Module/mech/mechdef_javelin_JVN-10F.json
+++ b/Urban Warfare Unit Module/mech/mechdef_javelin_JVN-10F.json
@@ -54,6 +54,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Urban Warfare Unit Module/mech/mechdef_javelin_JVN-10N.json
+++ b/Urban Warfare Unit Module/mech/mechdef_javelin_JVN-10N.json
@@ -54,6 +54,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Urban Warfare Unit Module/mech/mechdef_javelin_JVN-10P.json
+++ b/Urban Warfare Unit Module/mech/mechdef_javelin_JVN-10P.json
@@ -30,6 +30,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Urban Warfare Unit Module/mech/mechdef_javelin_JVN-11A.json
+++ b/Urban Warfare Unit Module/mech/mechdef_javelin_JVN-11A.json
@@ -30,6 +30,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Urban Warfare Unit Module/mech/mechdef_javelin_JVN-11B.json
+++ b/Urban Warfare Unit Module/mech/mechdef_javelin_JVN-11B.json
@@ -30,6 +30,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Urban Warfare Unit Module/mech/mechdef_raven_RVN-3M.json
+++ b/Urban Warfare Unit Module/mech/mechdef_raven_RVN-3M.json
@@ -39,6 +39,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Urban Warfare Unit Module/vehicle/vehicledef_GALLANT.json
+++ b/Urban Warfare Unit Module/vehicle/vehicledef_GALLANT.json
@@ -56,6 +56,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Urban Warfare Unit Module/vehicle/vehicledef_GALLANT_3050.json
+++ b/Urban Warfare Unit Module/vehicle/vehicledef_GALLANT_3050.json
@@ -56,6 +56,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Urban Warfare Unit Module/vehicle/vehicledef_GALLANT_FUSION.json
+++ b/Urban Warfare Unit Module/vehicle/vehicledef_GALLANT_FUSION.json
@@ -56,6 +56,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Urban Warfare Unit Module/vehicle/vehicledef_PACKRAT.json
+++ b/Urban Warfare Unit Module/vehicle/vehicledef_PACKRAT.json
@@ -67,7 +67,8 @@
 			"GraysGhosts",
 			"BroadswordLegion",
 			"Moderbjorn",
-			"BountyHunterAssociates",
+         "BountyHunterAssociates",
+         "BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
       ],

--- a/Urban Warfare Unit Module/vehicle/vehicledef_PACKRAT_BASE.json
+++ b/Urban Warfare Unit Module/vehicle/vehicledef_PACKRAT_BASE.json
@@ -67,6 +67,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Urban Warfare Unit Module/vehicle/vehicledef_PACKRAT_ICE.json
+++ b/Urban Warfare Unit Module/vehicle/vehicledef_PACKRAT_ICE.json
@@ -64,6 +64,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/Urban Warfare Unit Module/vehicle/vehicledef_ROTUNDA_RL.json
+++ b/Urban Warfare Unit Module/vehicle/vehicledef_ROTUNDA_RL.json
@@ -45,6 +45,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/apc/vehicledef_APC_HeavyWheeled.json
+++ b/VIPAdvanced/apc/vehicledef_APC_HeavyWheeled.json
@@ -60,6 +60,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/apc/vehicledef_APC_HeavyWheeled_LRM.json
+++ b/VIPAdvanced/apc/vehicledef_APC_HeavyWheeled_LRM.json
@@ -60,6 +60,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/apc/vehicledef_APC_HeavyWheeled_MG.json
+++ b/VIPAdvanced/apc/vehicledef_APC_HeavyWheeled_MG.json
@@ -59,6 +59,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/apc/vehicledef_APC_HeavyWheeled_SRM.json
+++ b/VIPAdvanced/apc/vehicledef_APC_HeavyWheeled_SRM.json
@@ -59,6 +59,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/apc/vehicledef_APC_Sleipnir.json
+++ b/VIPAdvanced/apc/vehicledef_APC_Sleipnir.json
@@ -60,6 +60,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/apc/vehicledef_APC_Sleipnir_LRM.json
+++ b/VIPAdvanced/apc/vehicledef_APC_Sleipnir_LRM.json
@@ -59,6 +59,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/apc/vehicledef_APC_Sleipnir_SRM.json
+++ b/VIPAdvanced/apc/vehicledef_APC_Sleipnir_SRM.json
@@ -59,6 +59,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/apc/vehicledef_APC_Vargr.json
+++ b/VIPAdvanced/apc/vehicledef_APC_Vargr.json
@@ -60,6 +60,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/apc/vehicledef_APC_Vargr_LRM.json
+++ b/VIPAdvanced/apc/vehicledef_APC_Vargr_LRM.json
@@ -59,6 +59,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/apc/vehicledef_APC_Vargr_SRM.json
+++ b/VIPAdvanced/apc/vehicledef_APC_Vargr_SRM.json
@@ -59,6 +59,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/apc/vehicledef_APC_Wheeled.json
+++ b/VIPAdvanced/apc/vehicledef_APC_Wheeled.json
@@ -60,6 +60,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/apc/vehicledef_APC_Wheeled_LRM.json
+++ b/VIPAdvanced/apc/vehicledef_APC_Wheeled_LRM.json
@@ -59,6 +59,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/apc/vehicledef_APC_Wheeled_MG.json
+++ b/VIPAdvanced/apc/vehicledef_APC_Wheeled_MG.json
@@ -58,6 +58,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/apc/vehicledef_APC_Wheeled_SRM.json
+++ b/VIPAdvanced/apc/vehicledef_APC_Wheeled_SRM.json
@@ -59,6 +59,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/apc/vehicledef_MASHTruck-ICE.json
+++ b/VIPAdvanced/apc/vehicledef_MASHTruck-ICE.json
@@ -63,6 +63,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/apc/vehicledef_MASHTruck-L.json
+++ b/VIPAdvanced/apc/vehicledef_MASHTruck-L.json
@@ -63,6 +63,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/apc/vehicledef_MASHTruck-UA.json
+++ b/VIPAdvanced/apc/vehicledef_MASHTruck-UA.json
@@ -64,6 +64,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/apc/vehicledef_MASHTruck.json
+++ b/VIPAdvanced/apc/vehicledef_MASHTruck.json
@@ -63,6 +63,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/apc/vehicledef_MOBILEHQ.json
+++ b/VIPAdvanced/apc/vehicledef_MOBILEHQ.json
@@ -58,6 +58,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/apc/vehicledef_MOBILEHQ_ARMORED.json
+++ b/VIPAdvanced/apc/vehicledef_MOBILEHQ_ARMORED.json
@@ -58,6 +58,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/assault/vehicledef_ALACORN_VI.json
+++ b/VIPAdvanced/assault/vehicledef_ALACORN_VI.json
@@ -56,6 +56,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/assault/vehicledef_BEHEMOTH.json
+++ b/VIPAdvanced/assault/vehicledef_BEHEMOTH.json
@@ -61,6 +61,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/assault/vehicledef_BEHEMOTHA.json
+++ b/VIPAdvanced/assault/vehicledef_BEHEMOTHA.json
@@ -49,6 +49,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/assault/vehicledef_BEHEMOTHF.json
+++ b/VIPAdvanced/assault/vehicledef_BEHEMOTHF.json
@@ -49,6 +49,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/assault/vehicledef_BEHEMOTH_KURITA.json
+++ b/VIPAdvanced/assault/vehicledef_BEHEMOTH_KURITA.json
@@ -49,6 +49,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/assault/vehicledef_CARRIER_HEAVYLRM.json
+++ b/VIPAdvanced/assault/vehicledef_CARRIER_HEAVYLRM.json
@@ -67,6 +67,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/assault/vehicledef_CARRIER_HEAVY_HYBRID_T15L20.json
+++ b/VIPAdvanced/assault/vehicledef_CARRIER_HEAVY_HYBRID_T15L20.json
@@ -67,6 +67,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/assault/vehicledef_CARRIER_HEAVY_TBM10.json
+++ b/VIPAdvanced/assault/vehicledef_CARRIER_HEAVY_TBM10.json
@@ -67,6 +67,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/assault/vehicledef_CHALLENGER_X.json
+++ b/VIPAdvanced/assault/vehicledef_CHALLENGER_X.json
@@ -45,6 +45,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/assault/vehicledef_DEMOLISHER.json
+++ b/VIPAdvanced/assault/vehicledef_DEMOLISHER.json
@@ -67,6 +67,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/assault/vehicledef_DEMOLISHERD.json
+++ b/VIPAdvanced/assault/vehicledef_DEMOLISHERD.json
@@ -66,6 +66,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/assault/vehicledef_DEMOLISHER_ARROWIV.json
+++ b/VIPAdvanced/assault/vehicledef_DEMOLISHER_ARROWIV.json
@@ -57,6 +57,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/assault/vehicledef_DEMOLISHER_GAUSS.json
+++ b/VIPAdvanced/assault/vehicledef_DEMOLISHER_GAUSS.json
@@ -54,6 +54,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/assault/vehicledef_DEVASTATOR.json
+++ b/VIPAdvanced/assault/vehicledef_DEVASTATOR.json
@@ -53,6 +53,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/assault/vehicledef_LONGTOM.json
+++ b/VIPAdvanced/assault/vehicledef_LONGTOM.json
@@ -66,6 +66,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/assault/vehicledef_ONTOS_3053.json
+++ b/VIPAdvanced/assault/vehicledef_ONTOS_3053.json
@@ -56,6 +56,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/assault/vehicledef_ONTOS_MK1.json
+++ b/VIPAdvanced/assault/vehicledef_ONTOS_MK1.json
@@ -54,6 +54,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/assault/vehicledef_PARTISAN.json
+++ b/VIPAdvanced/assault/vehicledef_PARTISAN.json
@@ -64,6 +64,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/assault/vehicledef_PARTISAN_AAA.json
+++ b/VIPAdvanced/assault/vehicledef_PARTISAN_AAA.json
@@ -52,6 +52,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/assault/vehicledef_PARTISAN_AC2.json
+++ b/VIPAdvanced/assault/vehicledef_PARTISAN_AC2.json
@@ -53,6 +53,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/assault/vehicledef_PARTISAN_LRM.json
+++ b/VIPAdvanced/assault/vehicledef_PARTISAN_LRM.json
@@ -56,6 +56,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/assault/vehicledef_RHINO.json
+++ b/VIPAdvanced/assault/vehicledef_RHINO.json
@@ -59,6 +59,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/assault/vehicledef_RHINO_FLAMER.json
+++ b/VIPAdvanced/assault/vehicledef_RHINO_FLAMER.json
@@ -60,6 +60,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/assault/vehicledef_RHINO_MG.json
+++ b/VIPAdvanced/assault/vehicledef_RHINO_MG.json
@@ -59,6 +59,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/assault/vehicledef_RHINO_SL.json
+++ b/VIPAdvanced/assault/vehicledef_RHINO_SL.json
@@ -59,6 +59,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/assault/vehicledef_SCHILTRON_A.json
+++ b/VIPAdvanced/assault/vehicledef_SCHILTRON_A.json
@@ -48,6 +48,7 @@
                   "BroadswordLegion",
                   "Moderbjorn",
                   "BountyHunterAssociates",
+                  "BaumannGroup",		
                   "BlackWidowCompany",
                   "unit_notsacellum"
             ],

--- a/VIPAdvanced/assault/vehicledef_SCHILTRON_B.json
+++ b/VIPAdvanced/assault/vehicledef_SCHILTRON_B.json
@@ -49,6 +49,7 @@
                   "BroadswordLegion",
                   "Moderbjorn",
                   "BountyHunterAssociates",
+                  "BaumannGroup",		
                   "BlackWidowCompany",
                   "unit_notsacellum"
             ],

--- a/VIPAdvanced/assault/vehicledef_SCHILTRON_C.json
+++ b/VIPAdvanced/assault/vehicledef_SCHILTRON_C.json
@@ -48,6 +48,7 @@
                   "BroadswordLegion",
                   "Moderbjorn",
                   "BountyHunterAssociates",
+                  "BaumannGroup",		
                   "BlackWidowCompany",
                   "unit_notsacellum"
             ],

--- a/VIPAdvanced/assault/vehicledef_SCHILTRON_D.json
+++ b/VIPAdvanced/assault/vehicledef_SCHILTRON_D.json
@@ -48,6 +48,7 @@
                   "BroadswordLegion",
                   "Moderbjorn",
                   "BountyHunterAssociates",
+                  "BaumannGroup",		
                   "BlackWidowCompany",
                   "unit_notsacellum"
             ],

--- a/VIPAdvanced/assault/vehicledef_SCHILTRON_PRIME.json
+++ b/VIPAdvanced/assault/vehicledef_SCHILTRON_PRIME.json
@@ -48,6 +48,7 @@
                   "BroadswordLegion",
                   "Moderbjorn",
                   "BountyHunterAssociates",
+                  "BaumannGroup",		
                   "BlackWidowCompany",
                   "unit_notsacellum"
             ],

--- a/VIPAdvanced/assault/vehicledef_SCHREK.json
+++ b/VIPAdvanced/assault/vehicledef_SCHREK.json
@@ -66,6 +66,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/assault/vehicledef_SCHREK_AC.json
+++ b/VIPAdvanced/assault/vehicledef_SCHREK_AC.json
@@ -66,6 +66,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/assault/vehicledef_SCHREK_MG.json
+++ b/VIPAdvanced/assault/vehicledef_SCHREK_MG.json
@@ -52,6 +52,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/heavy/vehicledef_BALLISTA.json
+++ b/VIPAdvanced/heavy/vehicledef_BALLISTA.json
@@ -66,6 +66,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/heavy/vehicledef_BRUTUS.json
+++ b/VIPAdvanced/heavy/vehicledef_BRUTUS.json
@@ -68,6 +68,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/heavy/vehicledef_BRUTUS_LRM.json
+++ b/VIPAdvanced/heavy/vehicledef_BRUTUS_LRM.json
@@ -55,6 +55,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/heavy/vehicledef_BRUTUS_PPC.json
+++ b/VIPAdvanced/heavy/vehicledef_BRUTUS_PPC.json
@@ -53,6 +53,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/heavy/vehicledef_BRUTUS_PPC2.json
+++ b/VIPAdvanced/heavy/vehicledef_BRUTUS_PPC2.json
@@ -53,6 +53,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/heavy/vehicledef_BULLDOG.json
+++ b/VIPAdvanced/heavy/vehicledef_BULLDOG.json
@@ -66,6 +66,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/heavy/vehicledef_BULLDOG_AC.json
+++ b/VIPAdvanced/heavy/vehicledef_BULLDOG_AC.json
@@ -65,6 +65,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/heavy/vehicledef_BULLDOG_LRM.json
+++ b/VIPAdvanced/heavy/vehicledef_BULLDOG_LRM.json
@@ -66,6 +66,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/heavy/vehicledef_CARRIER_AC2.json
+++ b/VIPAdvanced/heavy/vehicledef_CARRIER_AC2.json
@@ -66,6 +66,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/heavy/vehicledef_CARRIER_AC2_LBX.json
+++ b/VIPAdvanced/heavy/vehicledef_CARRIER_AC2_LBX.json
@@ -66,6 +66,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/heavy/vehicledef_CARRIER_HYBRID_10-5.json
+++ b/VIPAdvanced/heavy/vehicledef_CARRIER_HYBRID_10-5.json
@@ -67,6 +67,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/heavy/vehicledef_CARRIER_LASER.json
+++ b/VIPAdvanced/heavy/vehicledef_CARRIER_LASER.json
@@ -67,6 +67,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/heavy/vehicledef_CARRIER_LRM.json
+++ b/VIPAdvanced/heavy/vehicledef_CARRIER_LRM.json
@@ -67,6 +67,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/heavy/vehicledef_CARRIER_LRM_3055.json
+++ b/VIPAdvanced/heavy/vehicledef_CARRIER_LRM_3055.json
@@ -67,6 +67,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/heavy/vehicledef_CARRIER_MORTAR.json
+++ b/VIPAdvanced/heavy/vehicledef_CARRIER_MORTAR.json
@@ -67,6 +67,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/heavy/vehicledef_CARRIER_MRM.json
+++ b/VIPAdvanced/heavy/vehicledef_CARRIER_MRM.json
@@ -66,6 +66,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/heavy/vehicledef_CARRIER_SRM.json
+++ b/VIPAdvanced/heavy/vehicledef_CARRIER_SRM.json
@@ -66,6 +66,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/heavy/vehicledef_CARRIER_SRM_3054.json
+++ b/VIPAdvanced/heavy/vehicledef_CARRIER_SRM_3054.json
@@ -65,6 +65,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/heavy/vehicledef_CARRIER_TBM5.json
+++ b/VIPAdvanced/heavy/vehicledef_CARRIER_TBM5.json
@@ -67,6 +67,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/heavy/vehicledef_MANTICORE.json
+++ b/VIPAdvanced/heavy/vehicledef_MANTICORE.json
@@ -65,6 +65,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/heavy/vehicledef_MANTICORE_3055.json
+++ b/VIPAdvanced/heavy/vehicledef_MANTICORE_3055.json
@@ -42,6 +42,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/heavy/vehicledef_MANTICORE_ELITE.json
+++ b/VIPAdvanced/heavy/vehicledef_MANTICORE_ELITE.json
@@ -66,6 +66,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/heavy/vehicledef_MARKSMAN.json
+++ b/VIPAdvanced/heavy/vehicledef_MARKSMAN.json
@@ -66,6 +66,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/heavy/vehicledef_MARSDENII.json
+++ b/VIPAdvanced/heavy/vehicledef_MARSDENII.json
@@ -65,6 +65,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/heavy/vehicledef_MARSDENIIA.json
+++ b/VIPAdvanced/heavy/vehicledef_MARSDENIIA.json
@@ -65,6 +65,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/heavy/vehicledef_PATTON.json
+++ b/VIPAdvanced/heavy/vehicledef_PATTON.json
@@ -41,6 +41,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/heavy/vehicledef_PIKE.json
+++ b/VIPAdvanced/heavy/vehicledef_PIKE.json
@@ -65,6 +65,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/heavy/vehicledef_PO.json
+++ b/VIPAdvanced/heavy/vehicledef_PO.json
@@ -58,6 +58,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/heavy/vehicledef_ROMMEL.json
+++ b/VIPAdvanced/heavy/vehicledef_ROMMEL.json
@@ -42,6 +42,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/heavy/vehicledef_THUMPER.json
+++ b/VIPAdvanced/heavy/vehicledef_THUMPER.json
@@ -66,6 +66,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/heavy/vehicledef_ZHUKOV.json
+++ b/VIPAdvanced/heavy/vehicledef_ZHUKOV.json
@@ -64,6 +64,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/light/vehicledef_GALLEON.json
+++ b/VIPAdvanced/light/vehicledef_GALLEON.json
@@ -67,6 +67,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/light/vehicledef_GALLEON_GAL102.json
+++ b/VIPAdvanced/light/vehicledef_GALLEON_GAL102.json
@@ -68,6 +68,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/light/vehicledef_GALLEON_GAL200.json
+++ b/VIPAdvanced/light/vehicledef_GALLEON_GAL200.json
@@ -66,6 +66,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/light/vehicledef_HARASSER.json
+++ b/VIPAdvanced/light/vehicledef_HARASSER.json
@@ -67,6 +67,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/light/vehicledef_HUNTER.json
+++ b/VIPAdvanced/light/vehicledef_HUNTER.json
@@ -68,6 +68,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/light/vehicledef_HUNTER_AMMO.json
+++ b/VIPAdvanced/light/vehicledef_HUNTER_AMMO.json
@@ -56,6 +56,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/light/vehicledef_HUNTER_LRM10.json
+++ b/VIPAdvanced/light/vehicledef_HUNTER_LRM10.json
@@ -55,6 +55,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/light/vehicledef_HUNTER_LRM15.json
+++ b/VIPAdvanced/light/vehicledef_HUNTER_LRM15.json
@@ -56,6 +56,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/light/vehicledef_JEdgar.json
+++ b/VIPAdvanced/light/vehicledef_JEdgar.json
@@ -65,6 +65,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/light/vehicledef_PEGASUS.json
+++ b/VIPAdvanced/light/vehicledef_PEGASUS.json
@@ -68,6 +68,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/light/vehicledef_SALADIN.json
+++ b/VIPAdvanced/light/vehicledef_SALADIN.json
@@ -67,6 +67,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/light/vehicledef_SALADIN_ARMOR.json
+++ b/VIPAdvanced/light/vehicledef_SALADIN_ARMOR.json
@@ -67,6 +67,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/light/vehicledef_SARACEN.json
+++ b/VIPAdvanced/light/vehicledef_SARACEN.json
@@ -54,6 +54,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/light/vehicledef_SCIMITAR.json
+++ b/VIPAdvanced/light/vehicledef_SCIMITAR.json
@@ -54,6 +54,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/light/vehicledef_SCIMITAR_LRM.json
+++ b/VIPAdvanced/light/vehicledef_SCIMITAR_LRM.json
@@ -55,6 +55,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/light/vehicledef_SCORPION.json
+++ b/VIPAdvanced/light/vehicledef_SCORPION.json
@@ -59,6 +59,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/light/vehicledef_SCORPION_LRM.json
+++ b/VIPAdvanced/light/vehicledef_SCORPION_LRM.json
@@ -59,6 +59,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/light/vehicledef_SCORPION_ML.json
+++ b/VIPAdvanced/light/vehicledef_SCORPION_ML.json
@@ -59,6 +59,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/light/vehicledef_SCORPION_MRM.json
+++ b/VIPAdvanced/light/vehicledef_SCORPION_MRM.json
@@ -59,6 +59,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/light/vehicledef_SCORPION_SRM.json
+++ b/VIPAdvanced/light/vehicledef_SCORPION_SRM.json
@@ -59,6 +59,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/light/vehicledef_STRIKER.json
+++ b/VIPAdvanced/light/vehicledef_STRIKER.json
@@ -54,6 +54,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/light/vehicledef_STRIKER_AMMO.json
+++ b/VIPAdvanced/light/vehicledef_STRIKER_AMMO.json
@@ -54,6 +54,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/light/vehicledef_STRIKER_LRM.json
+++ b/VIPAdvanced/light/vehicledef_STRIKER_LRM.json
@@ -53,6 +53,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/light/vehicledef_STRIKER_SRM.json
+++ b/VIPAdvanced/light/vehicledef_STRIKER_SRM.json
@@ -53,6 +53,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/medium/vehicledef_APC_MAXIM.json
+++ b/VIPAdvanced/medium/vehicledef_APC_MAXIM.json
@@ -67,6 +67,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/medium/vehicledef_CARRIER_LIGHT_LRM.json
+++ b/VIPAdvanced/medium/vehicledef_CARRIER_LIGHT_LRM.json
@@ -48,6 +48,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/medium/vehicledef_CARRIER_LIGHT_MORTAR.json
+++ b/VIPAdvanced/medium/vehicledef_CARRIER_LIGHT_MORTAR.json
@@ -47,6 +47,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/medium/vehicledef_CARRIER_LIGHT_SRM.json
+++ b/VIPAdvanced/medium/vehicledef_CARRIER_LIGHT_SRM.json
@@ -47,6 +47,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/medium/vehicledef_CARRIER_LIGHT_TBM5.json
+++ b/VIPAdvanced/medium/vehicledef_CARRIER_LIGHT_TBM5.json
@@ -48,6 +48,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/medium/vehicledef_CONDOR.json
+++ b/VIPAdvanced/medium/vehicledef_CONDOR.json
@@ -65,6 +65,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/medium/vehicledef_CONDOR_LASER.json
+++ b/VIPAdvanced/medium/vehicledef_CONDOR_LASER.json
@@ -52,6 +52,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/medium/vehicledef_DRILLSON.json
+++ b/VIPAdvanced/medium/vehicledef_DRILLSON.json
@@ -66,6 +66,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/medium/vehicledef_DRILLSON_ICE.json
+++ b/VIPAdvanced/medium/vehicledef_DRILLSON_ICE.json
@@ -66,6 +66,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/medium/vehicledef_DRILLSON_SRM.json
+++ b/VIPAdvanced/medium/vehicledef_DRILLSON_SRM.json
@@ -65,6 +65,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/medium/vehicledef_FULCRUM_1.json
+++ b/VIPAdvanced/medium/vehicledef_FULCRUM_1.json
@@ -49,6 +49,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/medium/vehicledef_GOBLIN.json
+++ b/VIPAdvanced/medium/vehicledef_GOBLIN.json
@@ -57,6 +57,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/medium/vehicledef_GOBLIN_ISV.json
+++ b/VIPAdvanced/medium/vehicledef_GOBLIN_ISV.json
@@ -47,6 +47,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/medium/vehicledef_HETZER.json
+++ b/VIPAdvanced/medium/vehicledef_HETZER.json
@@ -66,6 +66,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/medium/vehicledef_HETZER_AC10.json
+++ b/VIPAdvanced/medium/vehicledef_HETZER_AC10.json
@@ -64,6 +64,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/medium/vehicledef_HETZER_LASER.json
+++ b/VIPAdvanced/medium/vehicledef_HETZER_LASER.json
@@ -51,6 +51,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/medium/vehicledef_HETZER_LRM.json
+++ b/VIPAdvanced/medium/vehicledef_HETZER_LRM.json
@@ -57,6 +57,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/medium/vehicledef_HETZER_SRM.json
+++ b/VIPAdvanced/medium/vehicledef_HETZER_SRM.json
@@ -64,6 +64,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/medium/vehicledef_MYRMIDON.json
+++ b/VIPAdvanced/medium/vehicledef_MYRMIDON.json
@@ -50,6 +50,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/medium/vehicledef_PROWLER.json
+++ b/VIPAdvanced/medium/vehicledef_PROWLER.json
@@ -64,6 +64,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/medium/vehicledef_TIGER.json
+++ b/VIPAdvanced/medium/vehicledef_TIGER.json
@@ -66,6 +66,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/medium/vehicledef_VEDETTE.json
+++ b/VIPAdvanced/medium/vehicledef_VEDETTE.json
@@ -66,6 +66,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/medium/vehicledef_VEDETTE_AC2.json
+++ b/VIPAdvanced/medium/vehicledef_VEDETTE_AC2.json
@@ -66,6 +66,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/medium/vehicledef_VEDETTE_NETC.json
+++ b/VIPAdvanced/medium/vehicledef_VEDETTE_NETC.json
@@ -53,6 +53,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],

--- a/VIPAdvanced/medium/vehicledef_ZEPHYR.json
+++ b/VIPAdvanced/medium/vehicledef_ZEPHYR.json
@@ -45,6 +45,7 @@
 			"BroadswordLegion",
 			"Moderbjorn",
 			"BountyHunterAssociates",
+			"BaumannGroup",		
 			"BlackWidowCompany",
 			"unit_notsacellum"
 		],


### PR DESCRIPTION
Somehow the Bauman group tag was never applied to anything. Did a find and replace in the BTA files to swap "BountyHunterAssociates",            
			"BlackWidowCompany",
with "BountyHunterAssociates",
			"BaumannGroup",		
			"BlackWidowCompany", since all 3 are Heavy Metal factions counting as mercs (the new tag should only be on Merc units or generic stuff)