### PR TITLE
Custom Mechs no longer depends on core

### DIFF
--- a/BT Advanced Custom Mechs/mod.json
+++ b/BT Advanced Custom Mechs/mod.json
@@ -1,7 +1,7 @@
 {
     "Name": "BT Advanced Custom Mechs",
     "Enabled": true,
-
+	"Hidden": true,
 	"Version": "1.0",
     "Description": "Contains scratch-built custom designs, made just for BTA.",
 


### PR DESCRIPTION
Its the other way around, core depends on BT Custom Mechs, no recursive loop to break it, also made Custom Mechs Hidden from the gui mods list