### PR TITLE
Unneeded (also delete BTA_Starters_Clan folder)

### DIFF
--- a/BT Advanced Starters/mod.json
+++ b/BT Advanced Starters/mod.json
@@ -10,7 +10,6 @@
 			"Manifest": [
 	{ "Path": "BTA_itemCollection_Mechs",		"Type": "ItemCollectionDef" },
 	{ "Path": "BTA_Starters_Base",				"Type": "AdvancedJSONMerge" },
-	{ "Path": "BTA_Starters_Clan",				"Type": "AdvancedJSONMerge" },
 	{ "Path": "BTA_Starters_Theme", 			"Type": "AdvancedJSONMerge" },
 
   ],


### PR DESCRIPTION
BTA_Starters_Clan serves no purpose if they're overwrites.  :fried_shrimp: