### PR TITLE
linux arrow explosion effect fix

### DIFF
--- a/LinuxFire/CustomAmmoCategoriesSettings.json
+++ b/LinuxFire/CustomAmmoCategoriesSettings.json
@@ -16,7 +16,7 @@
 	"BurningForestCellRadius": 3,
 	"BurningForestTurns": 2,
 	"AdditinalAssets": [
-		"vfx2",
+		"nuked",
 		"impact",
 		"nuka",
 		"glow",


### PR DESCRIPTION
reverted back to "nuked" instead of "vfx2"