### PR TITLE
fix FP loot tables

### DIFF
--- a/DynamicShops/StreamingAssets/data/itemCollections/itemCollection_loot_careerReward_1.csv
+++ b/DynamicShops/StreamingAssets/data/itemCollections/itemCollection_loot_careerReward_1.csv
@@ -1,3 +1,3 @@
 itemCollection_loot_careerReward_1,"Career Reward: Green","Career Reward: Green",
-BTA_standard_Minor,Reference,1,1
+BTA_standard_Minor_Loot,Reference,1,1
 ItemCollection_Internals_IS,Reference,1,1

--- a/DynamicShops/StreamingAssets/data/itemCollections/itemCollection_loot_careerReward_2.csv
+++ b/DynamicShops/StreamingAssets/data/itemCollections/itemCollection_loot_careerReward_2.csv
@@ -1,3 +1,3 @@
 itemCollection_loot_careerReward_2,"Career Reward: Regular","Career Reward: Regular",
-BTA_standard_Minor,Reference,2,1
+BTA_standard_Minor_Loot,Reference,2,1
 ItemCollection_Internals_IS,Reference,2,1

--- a/DynamicShops/StreamingAssets/data/itemCollections/itemCollection_loot_careerReward_3.csv
+++ b/DynamicShops/StreamingAssets/data/itemCollections/itemCollection_loot_careerReward_3.csv
@@ -1,3 +1,3 @@
 itemCollection_loot_careerReward_3,"Career Reward: Veteran","Career Reward: Veteran",
-BTA_standard_Major,Reference,2,1
+BTA_standard_Major_Loot,Reference,2,1
 ItemCollection_Internals_IS,Reference,2,1

--- a/DynamicShops/StreamingAssets/data/itemCollections/itemCollection_loot_careerReward_4.csv
+++ b/DynamicShops/StreamingAssets/data/itemCollections/itemCollection_loot_careerReward_4.csv
@@ -1,3 +1,3 @@
 itemCollection_loot_careerReward_4,"Career Reward: Elite","Career Reward: Elite",
-BTA_standard_Major,Reference,2,1
+BTA_standard_Major_Loot,Reference,2,1
 ItemCollection_Internals_IS_Rare,Reference,3,1

--- a/DynamicShops/StreamingAssets/data/itemCollections/itemCollection_table_AdditionalLoot.csv
+++ b/DynamicShops/StreamingAssets/data/itemCollections/itemCollection_table_AdditionalLoot.csv
@@ -1,2 +1,2 @@
 itemCollection_table_AdditionalLoot,,,
-BTA_standard_Major,Reference,4,1
+BTA_standard_Major_Loot,Reference,4,1

--- a/DynamicShops/StreamingAssets/data/itemCollections/itemCollection_table_AdditionalLoot_uncommon.csv
+++ b/DynamicShops/StreamingAssets/data/itemCollections/itemCollection_table_AdditionalLoot_uncommon.csv
@@ -1,2 +1,2 @@
 itemCollection_table_AdditionalLoot_uncommon,,,
-BTA_standard_Minor,Reference,5,1
+BTA_standard_Minor_Loot,Reference,5,1

--- a/DynamicShops/data/BTA_standard_Major_Loot.csv
+++ b/DynamicShops/data/BTA_standard_Major_Loot.csv
@@ -1,0 +1,7 @@
+BTA_standard_Major_Loot,,,
+itemCollection_Weapons_common,Reference,1,2
+itemCollection_Weapons_uncommon,Reference,1,1
+itemCollection_Weapons_rare,Reference,1,1
+itemCollection_Upgrades_common,Reference,1,2
+itemCollection_Upgrades_uncommon,Reference,1,2
+ItemCollection_SS_IS,Reference,1,2

--- a/DynamicShops/data/BTA_standard_Minor_Loot.csv
+++ b/DynamicShops/data/BTA_standard_Minor_Loot.csv
@@ -1,0 +1,6 @@
+BTA_standard_Minor_Loot,,,
+itemCollection_Weapons_base,Reference,1,2
+itemCollection_Weapons_common,Reference,1,1
+itemCollection_Weapons_uncommon,Reference,1,1
+itemCollection_Upgrades_common,Reference,1,2
+ItemCollection_SS_Perephiry,Reference,1,2


### PR DESCRIPTION
should hopefully fix FP loot tables. just redirected FP rewards to copies of `BTA_standard_Major` (named `BTA_standard_Major_Loot`) and `BTA_standard_Minor` (named `BTA_standard_Minor_Loot`) with the unlimited JJs, HS, Actuators, and Loans removed since it doesn't make sense for those to be in FP rewards anyway.