### PR TITLE
couple o' fixes

### DIFF
--- a/BT Advanced Core/mod.json
+++ b/BT Advanced Core/mod.json
@@ -10,7 +10,7 @@
 	"CustomResourceTypes": ["MEBonusDescriptions", "MECriticalEffects", "CCCategories", "CCDefaults", "CCTagRestrictions", "CustomSVGIcon"],
 	"DependsOn": [
 		"Merc Emblems", "BattletechPerformanceFix", "bd weapon rebalance", "Better AI", "BT Advanced Custom Mechs",
-		"BTA Contracts", "BTA Difficulty Settings", "BT Advanced Factions", "Xtreme Advanced Gear Component",
+		"BTA Contracts", "BTA Difficulty Settings", "BT Advanced Factions", "BT Advanced Gear Component",
 		"BT Advanced Lances", "BT Advanced Mech Quirks", "BT Advanced Mechs", "BT Advanced Tanks", "Select Pilots BTA Edition",
 		"CBTBehaviorsEnhanced", "cFixes", "CommanderPortraitLoader", "CommunityBundles", "CustomFilters",
 		"Custom Ammo Categories", "CustomComponents", "CustomLocalization", "CustomSalvage", "CustomUnits", "CustomVoices", 

--- a/BT Advanced Periphery/chassis/chassisdef_locust_LCT-1PA.json
+++ b/BT Advanced Periphery/chassis/chassisdef_locust_LCT-1PA.json
@@ -179,11 +179,11 @@
 				},
 				{
 					"Omni": false,
-					"WeaponMount": "Energy"
+					"WeaponMount": "AntiPersonnel"
 				},
 				{
 					"Omni": false,
-					"WeaponMount": "Energy"
+					"WeaponMount": "AntiPersonnel"
 				}
 			],
 			"Tonnage": 0,

--- a/CustomAmmoCategories/AIM_settings.json
+++ b/CustomAmmoCategories/AIM_settings.json
@@ -421,7 +421,7 @@
 
   /* When target is dead, skip "critical" or "damage" processing.  Default "critical".  Empty to not skip anything. */
 
-  "SkipBeatingDeadMech": "damage",
+  "SkipBeatingDeadMech": "",
 
   /* Overrides AICritChanceBaseMultiplier in CombatGameConstants.json.  Default 0.2, same as game.
    * Set to 1 for same crit chance as players, or set to 0 to prevent enemies and/or allies from dealing crit. */


### PR DESCRIPTION
To avoid the Some parts didnt load error from modtek, and I forgot the later was set this way for some reason, it apprently stops crits from proccessing properly "it breaks crit processing as a single damage state on item stops further crits from being processed" from LA in RT crew chat