### PR TITLE
Development

### DIFF
--- a/BetterAI/StreamingAssets/data/behaviorVariables/global.json
+++ b/BetterAI/StreamingAssets/data/behaviorVariables/global.json
@@ -546,7 +546,7 @@
       "k": "Float_HeatToDamageRatio",
       "v": {
         "type": "Float",
-        "floatVal": 2.0
+        "floatVal": 2.5
       }
     },
     {
@@ -1021,7 +1021,7 @@
       "k": "Float_SprintAppetitivePreferIdealWeaponRangeToHostileFactorWeight",
       "v": {
         "type": "Float",
-        "floatVal": 0.3
+        "floatVal": 0.5
       }
     },
     {
@@ -1166,7 +1166,7 @@
       "k": "Float_EvasiveToHitFloor",
       "v": {
         "type": "Float",
-        "floatVal": 10.0
+        "floatVal": 6.0
       }
     },
     {
@@ -1177,7 +1177,7 @@
       "k": "Float_MinimumSensorLockQuality",
       "v": {
         "type": "Float",
-        "floatVal": 55
+        "floatVal": 45
       }
     },
     {
@@ -1651,7 +1651,7 @@
       }
     },
     {
-	    /* Number of active probe targets before we even try to activate 
+	    /* Number of active probe targets before we even try to activate
 	       active probe */
       "k" : "Int_MinimumActiveProbeCount",
       "v" : {
@@ -1695,7 +1695,7 @@
     },
     {
 	    /* When calculatiing expected damage, how much to lerp between the damage divided by number of weapons and the damage if every hit
-	       was in the same location. 0 is damage divided and 1 is damage concentrated. 
+	       was in the same location. 0 is damage divided and 1 is damage concentrated.
 	       Increases with Float_GhostStateHysteresisMultiplierTurnIncrease */
       "k" : "Float_WeaponDamageSpreadLerpValue",
       "v" : {
@@ -1708,7 +1708,7 @@
       "k" : "Float_StructuralDamagePercentageMultiplier",
       "v" : {
         "type" : "Float",
-        "floatVal" : 1
+        "floatVal" : 1.2
       }
     },
     {
@@ -1720,7 +1720,7 @@
         "floatVal" : 0
       }
     },
-    {	
+    {
 	    /* For every round the ai does not shoot in ghost state, it adds to a mutiplier that increases the confidence in causing higher damage */
       "k" : "Float_GhostStateHysteresisMultiplierTurnIncrease",
       "v" : {
@@ -1728,7 +1728,7 @@
         "floatVal" : 0.3
       }
     },
-    {	
+    {
 	    /* Enables more precise predictions about expected damage by counting weapons in range and damage reductions of the unit*/
       "k" : "Bool_ExpectedDamageAccuracyIncrease",
       "v" : {
@@ -1753,7 +1753,7 @@
       }
     },
     {
-            /* Weight penalty multiplier for losing the ECM counter aura when positioning. 
+            /* Weight penalty multiplier for losing the ECM counter aura when positioning.
                If set to 1, it represents -Float_PreferHostileECMFields or -Float_SprintPreferHostileECMFields*/
       "k": "Float_PreferHostileECMFieldsPenaltyMultiplier",
       "v": {
@@ -1795,7 +1795,7 @@
       "k": "Float_SprintPreferAttackFromBehindHostileFactorWeight",
       "v": {
         "type": "Float",
-        "floatVal": 0.1
+        "floatVal": 0.5
       }
     },
     {
@@ -1862,7 +1862,7 @@
       "k": "Float_PreferLOSToMostHostilesFactorWeight",
       "v": {
         "type": "Float",
-        "floatVal": 0.4
+        "floatVal": 0.3
       }
     },
     {
@@ -1907,7 +1907,7 @@
       "k": "Float_SprintPreferLowerStabilityDamageMultiplierLocationsFactorWeight",
       "v": {
         "type": "Float",
-        "floatVal": 0.3
+        "floatVal": 0.2
       }
     },
     {

--- a/Flashpoint DLC Flashpoints/contracts/heroduel/HeroDuel_Catapharact.json
+++ b/Flashpoint DLC Flashpoints/contracts/heroduel/HeroDuel_Catapharact.json
@@ -1,0 +1,423 @@
+{
+  "ID": "HeroDuel_Catapharact",
+  "contractName": "",
+  "contractDisplayStyle": "BaseFlashpoint",
+  "difficulty": 6,
+  "difficultyUIModifier": 0,
+  "weight": 1,
+  "scope": "STANDARD",
+  "finalDifficulty": 0,
+  "representativeCastDefIDOverride": null,
+  "missionSuccessStatementOverride": null,
+  "badFaithStatementOverride": null,
+  "goodFaithStatementOverride": null,
+  "shortDescription": "Our gladiator awaits your arrival. Their fans are clamouring to see them match against someone of your reputation, and we're ready to broadcast the event all over the Solaris VII tournament circuit. Good luck, and make the fight one to remember.",
+  "longDescription": "There's worse ways to make money than a prize-fight in front of millions. No moral ambiguity here - we're just in it for their mech, they're just in it for the fame.",
+  "salvagePotential": 4,
+  "requirementList": [
+      {
+            "Scope": "Company",
+            "RequirementTags": {
+                "tagSetSourceFile": "",
+                "items": []
+            },
+            "ExclusionTags": {
+                "tagSetSourceFile": "Tags/CompanyTags",
+                "items": [
+                    "flashpoint_HeroDuel_Catapharact"
+                ]
+            },
+            "RequirementComparisons": []
+        }
+  ],
+  "OnContractSuccessResults": [
+      {
+          "Scope": "Company",
+          "Requirements": {
+              "Scope": "Company",
+              "RequirementTags": {
+                  "tagSetSourceFile": "",
+                  "items": []
+              },
+              "ExclusionTags": {},
+              "RequirementComparisons": []
+          },
+          "AddedTags": {
+              "items": [
+                  "flashpoint_HeroDuel_Catapharact",
+                  "flashpoint_HeroDuel_Catapharact_temp"
+              ],
+              "tagSetSourceFile": "Tags/CompanyTags"
+          },
+          "RemovedTags": {},
+          "Stats": null,
+          "Actions": [],
+          "ForceEvents": [],
+          "TemporaryResult": false,
+          "ResultDuration": 0
+      }
+  ],
+  "OnContractFailureResults": [],
+  "encounterPlayStyle": "SinglePlayer",
+  "maxNumberOfPlayerUnits": 1,
+  "lanceMinTonnage": -1,
+  "lanceMaxTonnage": -1,
+  "mechMinTonnages": [-1, -1, -1, -1],
+  "mechMaxTonnages": [75, -1, -1, -1],
+  "mapMood": null,
+  "startingFogOfWarVisibility": "Surveyed",
+  "contractObjectiveList": [
+    {
+      "contractObjective": {
+        "EncounterObjectGuid": "73275787-720a-4c33-9f20-953b1bbf48bd"
+      },
+      "title": "Overcome the gladiator",
+      "description": "",
+      "isPrimary": true,
+      "forPlayer": "Player1",
+      "objectiveGuids": ["a0b9c5b2-c594-4c5a-be1d-028a51c51519"]
+    }
+  ],
+  "objectiveList": [
+    {
+      "objective": {
+        "EncounterObjectGuid": "a0b9c5b2-c594-4c5a-be1d-028a51c51519"
+      },
+      "title": "Overcome the gladiator",
+      "description": "",
+      "isPrimary": true,
+      "OnSuccessResults": [],
+      "OnFailureResults": [],
+      "OnSuccessDialogueGUID": null,
+      "OnFailureDialogueGUID": null
+    }
+  ],
+  "artilleryObjectiveList": [],
+  "buildingList": [],
+  "chunkList": [
+    {
+      "name": "Chunk_SwapSpawnerPlacement",
+      "encounterChunk": {
+        "EncounterObjectGuid": "ed007c52-f4cb-4bfc-842a-a50454d8a82a"
+      },
+      "enableChunkFromContract": true
+    }
+  ],
+  "cameraFocusHelperList": [
+    {
+      "name": "Spawner_PlayerLance",
+      "encounterObject": {
+        "EncounterObjectGuid": "76b654a6-4f2c-4a6f-86e6-d4cf868335fe"
+      }
+    },
+    {
+      "name": "Lance_Enemy_Combatant",
+      "encounterObject": {
+        "EncounterObjectGuid": "f426f0dc-969d-477d-81a9-d02f9e1eff79"
+      }
+    }
+  ],
+  "dialogueList": [
+    {
+      "dialogue": {
+        "EncounterObjectGuid": "73df8d9c-a274-48fd-98c9-2bd0d7860e83"
+      },
+      "name": "Dialogue_MissionStart",
+      "overrideDialogueBucketId": "",
+      "dialogueContent": [
+        {
+          "words": "Here we go, Commander.",
+          "wordsColor": {
+            "r": 1,
+            "g": 1,
+            "b": 1,
+            "a": 1
+          },
+          "selectedCastDefId": "castDef_DariusDefault",
+          "emote": "Default",
+          "audioName": "NONE",
+          "cameraFocusGuid": "",
+          "cameraDistance": "Far",
+          "cameraHeight": "Default",
+          "revealRadius": -1
+        },
+        {
+          "words": "Ironwood Studios has cameras rolling from all angles. Time to show them a thing or two, Commander.",
+          "wordsColor": {
+            "r": 1,
+            "g": 1,
+            "b": 1,
+            "a": 1
+          },
+          "selectedCastDefId": "castDef_DariusDefault",
+          "emote": "Default",
+          "audioName": "NONE",
+          "cameraFocusGuid": "",
+          "cameraDistance": "Far",
+          "cameraHeight": "Default",
+          "revealRadius": -1
+        }
+      ]
+    },
+    {
+      "dialogue": {
+        "EncounterObjectGuid": "4011a4c3-cba2-4d22-b2b3-3b19a3297ab9"
+      },
+      "name": "Dialogue_MissionSuccess",
+      "overrideDialogueBucketId": "",
+      "dialogueContent": [
+        {
+          "words": "Good show, Commander. Let's collect our prize and get out of here.",
+          "wordsColor": {
+            "r": 1,
+            "g": 1,
+            "b": 1,
+            "a": 1
+          },
+          "selectedCastDefId": "castDef_DariusDefault",
+          "emote": "Default",
+          "audioName": "NONE",
+          "cameraFocusGuid": "",
+          "cameraDistance": "Far",
+          "cameraHeight": "Default",
+          "revealRadius": -1
+        }
+      ]
+    },
+    {
+      "dialogue": {
+        "EncounterObjectGuid": "d3d33d95-9ed7-4686-b9eb-954ebe51cc02"
+      },
+      "name": "Dialogue_MissionFailure",
+      "overrideDialogueBucketId": "",
+      "dialogueContent": [
+        {
+          "words": "Let's get out of here. This is going to leave a dent in our reputation.",
+          "wordsColor": {
+            "r": 1,
+            "g": 1,
+            "b": 1,
+            "a": 1
+          },
+          "selectedCastDefId": "castDef_DariusDefault",
+          "emote": "Default",
+          "audioName": "NONE",
+          "cameraFocusGuid": "",
+          "cameraDistance": "Far",
+          "cameraHeight": "Default",
+          "revealRadius": -1
+        }
+      ]
+    }
+  ],
+  "extractionOverrideList": [],
+  "overwriteMissionCompleteWhenAutoComplete": true,
+  "overrideAutoCompleteDialogueId": null,
+  "disableNegotations": true,
+  "disableLanceConfiguration": false,
+  "disableCancelButton": false,
+  "disableAfterAction": false,
+  "contractRewardOverride": -1,
+  "travelOnly": false,
+  "useTravelCostPenalty": false,
+  "usesExpiration": false,
+  "expirationTimeOverride": -1,
+  "negotiatedSalary": 1,
+  "negotiatedSalvage": 0,
+  "excludedFromProceduralGeneration": true,
+  "player1Team": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "bf40fd39-ccf9-47c4-94a6-061809681140",
+    "teamName": "Player 1",
+    "faction": "Player1sMercUnit",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": [
+      {
+        "lanceSpawner": {
+          "EncounterObjectGuid": "76b654a6-4f2c-4a6f-86e6-d4cf868335fe"
+        },
+        "name": "Spawner_PlayerLance",
+        "lanceDefId": "Manual",
+        "lanceTagSet": {
+          "items": [],
+          "tagSetSourceFile": "tags/LanceTags"
+        },
+        "lanceExcludedTagSet": {
+          "items": [],
+          "tagSetSourceFile": "tags/LanceTags"
+        },
+        "spawnEffectTags": {
+          "items": [],
+          "tagSetSourceFile": "tags/SpawnEffectTags"
+        },
+        "lanceDifficultyAdjustment": 0,
+        "selectedLanceDefId": null,
+        "selectedLanceDifficulty": 0,
+        "unitSpawnPointOverrideList": [
+          {
+            "unitSpawnPoint": {
+              "EncounterObjectGuid": "ec9d2280-ca9a-4d90-8a20-963d8a4c0a39"
+            },
+            "customUnitName": null,
+            "customHeraldryDefId": null,
+            "unitType": "Mech",
+            "unitDefId": "mechDef_None",
+            "unitTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/UnitTags"
+            },
+            "unitExcludedTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/UnitTags"
+            },
+            "spawnEffectTags": {
+              "items": [],
+              "tagSetSourceFile": "tags/SpawnEffectTags"
+            },
+            "pilotDefId": "pilotDef_InheritLance",
+            "pilotTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/PilotTags"
+            },
+            "pilotExcludedTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/PilotTags"
+            },
+            "selectedUnitType": "UNDEFINED",
+            "selectedUnitDefId": null,
+            "selectedPilotDefId": null
+          }
+        ]
+      }
+    ]
+  },
+  "player2Team": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "757173dd-b4e1-4bb5-9bee-d78e623cc867",
+    "teamName": "Player 2",
+    "faction": "Player2sMercUnit",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "employerTeam": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "ecc8d4f2-74b4-465d-adf6-84445e5dfc230",
+    "teamName": "Employer",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "targetTeam": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "be77cadd-e245-4240-a93e-b99cc98902a5",
+    "teamName": "Target",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": [
+      {
+        "lanceSpawner": {
+          "EncounterObjectGuid": "f426f0dc-969d-477d-81a9-d02f9e1eff79"
+        },
+        "name": "Lance_Enemy_Champion",
+        "lanceDefId": "Manual",
+        "lanceTagSet": {
+          "items": [],
+          "tagSetSourceFile": "tags/LanceTags"
+        },
+        "lanceExcludedTagSet": {
+          "items": [],
+          "tagSetSourceFile": "tags/LanceTags"
+        },
+        "spawnEffectTags": {
+          "items": [],
+          "tagSetSourceFile": "tags/SpawnEffectTags"
+        },
+        "lanceDifficultyAdjustment": 0,
+        "selectedLanceDefId": null,
+        "selectedLanceDifficulty": 0,
+        "unitSpawnPointOverrideList": [
+          {
+            "unitSpawnPoint": {
+              "EncounterObjectGuid": "6cd3107e-0f9d-4809-ab8c-fb30faf4cd80"
+            },
+            "customUnitName": null,
+            "customHeraldryDefId": "",
+            "unitType": "Mech",
+            "unitDefId": "mechdef_cataphract_CTF-IM",
+            "unitTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/UnitTags"
+            },
+            "unitExcludedTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/UnitTags"
+            },
+            "spawnEffectTags": {
+              "items": [],
+              "tagSetSourceFile": "tags/SpawnEffectTags"
+            },
+            "pilotDefId": "pilotDef_InheritLance",
+            "pilotTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/PilotTags"
+            },
+            "pilotExcludedTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/PilotTags"
+            },
+            "selectedUnitType": "UNDEFINED",
+            "selectedUnitDefId": "",
+            "selectedPilotDefId": ""
+          }
+        ]
+      }
+    ]
+  },
+  "targetsAllyTeam": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "31151ed6-cfc2-467e-98c4-9ae5bea784cf",
+    "teamName": "Target's Ally",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "neutralToAllTeam": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "61612bb3-abf9-4586-952a-0559fa9dcd75",
+    "teamName": "Neutral to All",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "hostileToAllTeam": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "3c9f3a20-ab03-4bcb-8ab6-b1ef0442bbf0",
+    "teamName": "Hostile to All",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "employersAllyTeam": {
+    "encounterLayerData": null,
+    "teamGuid": "70af7e7f-39a8-4e81-87c2-bd01dcb01b5e",
+    "teamName": "Employers Ally",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "contractTypeID": "HeroDuel"
+}

--- a/Flashpoint DLC Flashpoints/contracts/heroduel/HeroDuel_Cicada.json
+++ b/Flashpoint DLC Flashpoints/contracts/heroduel/HeroDuel_Cicada.json
@@ -1,0 +1,423 @@
+{
+  "ID": "HeroDuel_Cicada",
+  "contractName": "",
+  "contractDisplayStyle": "BaseFlashpoint",
+  "difficulty": 6,
+  "difficultyUIModifier": 0,
+  "weight": 1,
+  "scope": "STANDARD",
+  "finalDifficulty": 0,
+  "representativeCastDefIDOverride": null,
+  "missionSuccessStatementOverride": null,
+  "badFaithStatementOverride": null,
+  "goodFaithStatementOverride": null,
+  "shortDescription": "Our gladiator awaits your arrival. Their fans are clamouring to see them match against someone of your reputation, and we're ready to broadcast the event all over the Solaris VII tournament circuit. Good luck, and make the fight one to remember.",
+  "longDescription": "There's worse ways to make money than a prize-fight in front of millions. No moral ambiguity here - we're just in it for their mech, they're just in it for the fame.",
+  "salvagePotential": 4,
+  "requirementList": [
+      {
+            "Scope": "Company",
+            "RequirementTags": {
+                "tagSetSourceFile": "",
+                "items": []
+            },
+            "ExclusionTags": {
+                "tagSetSourceFile": "Tags/CompanyTags",
+                "items": [
+                    "flashpoint_HeroDuel_Cicada"
+                ]
+            },
+            "RequirementComparisons": []
+        }
+  ],
+  "OnContractSuccessResults": [
+      {
+          "Scope": "Company",
+          "Requirements": {
+              "Scope": "Company",
+              "RequirementTags": {
+                  "tagSetSourceFile": "",
+                  "items": []
+              },
+              "ExclusionTags": {},
+              "RequirementComparisons": []
+          },
+          "AddedTags": {
+              "items": [
+                  "flashpoint_HeroDuel_Cicada",
+                  "flashpoint_HeroDuel_Cicada_temp"
+              ],
+              "tagSetSourceFile": "Tags/CompanyTags"
+          },
+          "RemovedTags": {},
+          "Stats": null,
+          "Actions": [],
+          "ForceEvents": [],
+          "TemporaryResult": false,
+          "ResultDuration": 0
+      }
+  ],
+  "OnContractFailureResults": [],
+  "encounterPlayStyle": "SinglePlayer",
+  "maxNumberOfPlayerUnits": 1,
+  "lanceMinTonnage": -1,
+  "lanceMaxTonnage": -1,
+  "mechMinTonnages": [-1, -1, -1, -1],
+  "mechMaxTonnages": [45, -1, -1, -1],
+  "mapMood": null,
+  "startingFogOfWarVisibility": "Surveyed",
+  "contractObjectiveList": [
+    {
+      "contractObjective": {
+        "EncounterObjectGuid": "73275787-720a-4c33-9f20-953b1bbf48bd"
+      },
+      "title": "Overcome the gladiator",
+      "description": "",
+      "isPrimary": true,
+      "forPlayer": "Player1",
+      "objectiveGuids": ["a0b9c5b2-c594-4c5a-be1d-028a51c51519"]
+    }
+  ],
+  "objectiveList": [
+    {
+      "objective": {
+        "EncounterObjectGuid": "a0b9c5b2-c594-4c5a-be1d-028a51c51519"
+      },
+      "title": "Overcome the gladiator",
+      "description": "",
+      "isPrimary": true,
+      "OnSuccessResults": [],
+      "OnFailureResults": [],
+      "OnSuccessDialogueGUID": null,
+      "OnFailureDialogueGUID": null
+    }
+  ],
+  "artilleryObjectiveList": [],
+  "buildingList": [],
+  "chunkList": [
+    {
+      "name": "Chunk_SwapSpawnerPlacement",
+      "encounterChunk": {
+        "EncounterObjectGuid": "ed007c52-f4cb-4bfc-842a-a50454d8a82a"
+      },
+      "enableChunkFromContract": true
+    }
+  ],
+  "cameraFocusHelperList": [
+    {
+      "name": "Spawner_PlayerLance",
+      "encounterObject": {
+        "EncounterObjectGuid": "76b654a6-4f2c-4a6f-86e6-d4cf868335fe"
+      }
+    },
+    {
+      "name": "Lance_Enemy_Combatant",
+      "encounterObject": {
+        "EncounterObjectGuid": "f426f0dc-969d-477d-81a9-d02f9e1eff79"
+      }
+    }
+  ],
+  "dialogueList": [
+    {
+      "dialogue": {
+        "EncounterObjectGuid": "73df8d9c-a274-48fd-98c9-2bd0d7860e83"
+      },
+      "name": "Dialogue_MissionStart",
+      "overrideDialogueBucketId": "",
+      "dialogueContent": [
+        {
+          "words": "Here we go, Commander.",
+          "wordsColor": {
+            "r": 1,
+            "g": 1,
+            "b": 1,
+            "a": 1
+          },
+          "selectedCastDefId": "castDef_DariusDefault",
+          "emote": "Default",
+          "audioName": "NONE",
+          "cameraFocusGuid": "",
+          "cameraDistance": "Far",
+          "cameraHeight": "Default",
+          "revealRadius": -1
+        },
+        {
+          "words": "Ironwood Studios has cameras rolling from all angles. Time to show them a thing or two, Commander.",
+          "wordsColor": {
+            "r": 1,
+            "g": 1,
+            "b": 1,
+            "a": 1
+          },
+          "selectedCastDefId": "castDef_DariusDefault",
+          "emote": "Default",
+          "audioName": "NONE",
+          "cameraFocusGuid": "",
+          "cameraDistance": "Far",
+          "cameraHeight": "Default",
+          "revealRadius": -1
+        }
+      ]
+    },
+    {
+      "dialogue": {
+        "EncounterObjectGuid": "4011a4c3-cba2-4d22-b2b3-3b19a3297ab9"
+      },
+      "name": "Dialogue_MissionSuccess",
+      "overrideDialogueBucketId": "",
+      "dialogueContent": [
+        {
+          "words": "Good show, Commander. Let's collect our prize and get out of here.",
+          "wordsColor": {
+            "r": 1,
+            "g": 1,
+            "b": 1,
+            "a": 1
+          },
+          "selectedCastDefId": "castDef_DariusDefault",
+          "emote": "Default",
+          "audioName": "NONE",
+          "cameraFocusGuid": "",
+          "cameraDistance": "Far",
+          "cameraHeight": "Default",
+          "revealRadius": -1
+        }
+      ]
+    },
+    {
+      "dialogue": {
+        "EncounterObjectGuid": "d3d33d95-9ed7-4686-b9eb-954ebe51cc02"
+      },
+      "name": "Dialogue_MissionFailure",
+      "overrideDialogueBucketId": "",
+      "dialogueContent": [
+        {
+          "words": "Let's get out of here. This is going to leave a dent in our reputation.",
+          "wordsColor": {
+            "r": 1,
+            "g": 1,
+            "b": 1,
+            "a": 1
+          },
+          "selectedCastDefId": "castDef_DariusDefault",
+          "emote": "Default",
+          "audioName": "NONE",
+          "cameraFocusGuid": "",
+          "cameraDistance": "Far",
+          "cameraHeight": "Default",
+          "revealRadius": -1
+        }
+      ]
+    }
+  ],
+  "extractionOverrideList": [],
+  "overwriteMissionCompleteWhenAutoComplete": true,
+  "overrideAutoCompleteDialogueId": null,
+  "disableNegotations": true,
+  "disableLanceConfiguration": false,
+  "disableCancelButton": false,
+  "disableAfterAction": false,
+  "contractRewardOverride": -1,
+  "travelOnly": false,
+  "useTravelCostPenalty": false,
+  "usesExpiration": false,
+  "expirationTimeOverride": -1,
+  "negotiatedSalary": 1,
+  "negotiatedSalvage": 0,
+  "excludedFromProceduralGeneration": true,
+  "player1Team": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "bf40fd39-ccf9-47c4-94a6-061809681140",
+    "teamName": "Player 1",
+    "faction": "Player1sMercUnit",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": [
+      {
+        "lanceSpawner": {
+          "EncounterObjectGuid": "76b654a6-4f2c-4a6f-86e6-d4cf868335fe"
+        },
+        "name": "Spawner_PlayerLance",
+        "lanceDefId": "Manual",
+        "lanceTagSet": {
+          "items": [],
+          "tagSetSourceFile": "tags/LanceTags"
+        },
+        "lanceExcludedTagSet": {
+          "items": [],
+          "tagSetSourceFile": "tags/LanceTags"
+        },
+        "spawnEffectTags": {
+          "items": [],
+          "tagSetSourceFile": "tags/SpawnEffectTags"
+        },
+        "lanceDifficultyAdjustment": 0,
+        "selectedLanceDefId": null,
+        "selectedLanceDifficulty": 0,
+        "unitSpawnPointOverrideList": [
+          {
+            "unitSpawnPoint": {
+              "EncounterObjectGuid": "ec9d2280-ca9a-4d90-8a20-963d8a4c0a39"
+            },
+            "customUnitName": null,
+            "customHeraldryDefId": null,
+            "unitType": "Mech",
+            "unitDefId": "mechDef_None",
+            "unitTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/UnitTags"
+            },
+            "unitExcludedTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/UnitTags"
+            },
+            "spawnEffectTags": {
+              "items": [],
+              "tagSetSourceFile": "tags/SpawnEffectTags"
+            },
+            "pilotDefId": "pilotDef_InheritLance",
+            "pilotTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/PilotTags"
+            },
+            "pilotExcludedTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/PilotTags"
+            },
+            "selectedUnitType": "UNDEFINED",
+            "selectedUnitDefId": null,
+            "selectedPilotDefId": null
+          }
+        ]
+      }
+    ]
+  },
+  "player2Team": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "757173dd-b4e1-4bb5-9bee-d78e623cc867",
+    "teamName": "Player 2",
+    "faction": "Player2sMercUnit",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "employerTeam": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "ecc8d4f2-74b4-465d-adf6-84445e5dfc230",
+    "teamName": "Employer",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "targetTeam": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "be77cadd-e245-4240-a93e-b99cc98902a5",
+    "teamName": "Target",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": [
+      {
+        "lanceSpawner": {
+          "EncounterObjectGuid": "f426f0dc-969d-477d-81a9-d02f9e1eff79"
+        },
+        "name": "Lance_Enemy_Champion",
+        "lanceDefId": "Manual",
+        "lanceTagSet": {
+          "items": [],
+          "tagSetSourceFile": "tags/LanceTags"
+        },
+        "lanceExcludedTagSet": {
+          "items": [],
+          "tagSetSourceFile": "tags/LanceTags"
+        },
+        "spawnEffectTags": {
+          "items": [],
+          "tagSetSourceFile": "tags/SpawnEffectTags"
+        },
+        "lanceDifficultyAdjustment": 0,
+        "selectedLanceDefId": null,
+        "selectedLanceDifficulty": 0,
+        "unitSpawnPointOverrideList": [
+          {
+            "unitSpawnPoint": {
+              "EncounterObjectGuid": "6cd3107e-0f9d-4809-ab8c-fb30faf4cd80"
+            },
+            "customUnitName": null,
+            "customHeraldryDefId": "",
+            "unitType": "Mech",
+            "unitDefId": "mechdef_cicada_CDA-X5",
+            "unitTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/UnitTags"
+            },
+            "unitExcludedTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/UnitTags"
+            },
+            "spawnEffectTags": {
+              "items": [],
+              "tagSetSourceFile": "tags/SpawnEffectTags"
+            },
+            "pilotDefId": "pilotDef_InheritLance",
+            "pilotTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/PilotTags"
+            },
+            "pilotExcludedTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/PilotTags"
+            },
+            "selectedUnitType": "UNDEFINED",
+            "selectedUnitDefId": "",
+            "selectedPilotDefId": ""
+          }
+        ]
+      }
+    ]
+  },
+  "targetsAllyTeam": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "31151ed6-cfc2-467e-98c4-9ae5bea784cf",
+    "teamName": "Target's Ally",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "neutralToAllTeam": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "61612bb3-abf9-4586-952a-0559fa9dcd75",
+    "teamName": "Neutral to All",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "hostileToAllTeam": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "3c9f3a20-ab03-4bcb-8ab6-b1ef0442bbf0",
+    "teamName": "Hostile to All",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "employersAllyTeam": {
+    "encounterLayerData": null,
+    "teamGuid": "70af7e7f-39a8-4e81-87c2-bd01dcb01b5e",
+    "teamName": "Employers Ally",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "contractTypeID": "HeroDuel"
+}

--- a/Flashpoint DLC Flashpoints/contracts/heroduel/SoloDuel_ATasteForWar.json
+++ b/Flashpoint DLC Flashpoints/contracts/heroduel/SoloDuel_ATasteForWar.json
@@ -1,0 +1,402 @@
+{
+  "ID": "SoloDuel_ATasteForWar",
+  "contractName": "A Taste For War",
+  "contractDisplayStyle": "BaseCampaignNormal",
+  "difficulty": 8,
+  "difficultyUIModifier": 0,
+  "weight": 1,
+  "scope": "STANDARD",
+  "finalDifficulty": 0,
+  "representativeCastDefIDOverride": null,
+  "missionSuccessStatementOverride": null,
+  "badFaithStatementOverride": null,
+  "goodFaithStatementOverride": null,
+  "shortDescription": "A prized {TEAM_TAR.FactionDef.Demonym} Gladiator has challenged you to solo combat, Commander. The holovid rights have already been sold to the highest bidder and we've already been wired a cut. We can't turn this chance down so we hope you can't too! We'll throw in the holo-vid footage for {COMPANY.CompanyName}'s promotional vids.",
+  "longDescription": "Commander, this seems like a straight up duel. It's based in an established arena so I guess it's as good as we'll get to 'safe'.",
+  "salvagePotential": 4,
+  "requirementList": [
+    {
+      "Scope": "StarSystem",
+      "RequirementTags": {
+        "items": [],
+        "tagSetSourceFile": ""
+      },
+      "ExclusionTags": {
+        "items": [],
+        "tagSetSourceFile": ""
+      },
+      "RequirementComparisons": [
+        {
+          "obj": "Employer.IsOwner",
+          "op": "Equal",
+          "val": 1,
+          "valueConstant": null
+        }
+      ]
+    }
+  ],
+  "OnContractSuccessResults": [],
+  "OnContractFailureResults": [],
+  "encounterPlayStyle": "SinglePlayer",
+  "maxNumberOfPlayerUnits": 1,
+  "lanceMinTonnage": -1,
+  "lanceMaxTonnage": -1,
+  "mechMinTonnages": [-1, -1, -1, -1],
+  "mechMaxTonnages": [-1, -1, -1, -1],
+  "mapMood": null,
+  "startingFogOfWarVisibility": "Surveyed",
+  "contractObjectiveList": [
+    {
+      "contractObjective": {
+        "EncounterObjectGuid": "73275787-720a-4c33-9f20-953b1bbf48bd"
+      },
+      "title": "Overcome the champion",
+      "description": "",
+      "isPrimary": true,
+      "forPlayer": "Player1",
+      "objectiveGuids": ["a0b9c5b2-c594-4c5a-be1d-028a51c51519"]
+    }
+  ],
+  "objectiveList": [
+    {
+      "objective": {
+        "EncounterObjectGuid": "a0b9c5b2-c594-4c5a-be1d-028a51c51519"
+      },
+      "title": "Destroy Enemy Champion",
+      "description": "",
+      "isPrimary": true,
+      "OnSuccessResults": [],
+      "OnFailureResults": [],
+      "OnSuccessDialogueGUID": null,
+      "OnFailureDialogueGUID": null
+    }
+  ],
+  "artilleryObjectiveList": [],
+  "buildingList": [],
+  "chunkList": [
+    {
+      "name": "Chunk_SwapSpawnerPlacement",
+      "encounterChunk": {
+        "EncounterObjectGuid": "ed007c52-f4cb-4bfc-842a-a50454d8a82a"
+      },
+      "enableChunkFromContract": true
+    }
+  ],
+  "cameraFocusHelperList": [
+    {
+      "name": "Spawner_PlayerLance",
+      "encounterObject": {
+        "EncounterObjectGuid": "76b654a6-4f2c-4a6f-86e6-d4cf868335fe"
+      }
+    },
+    {
+      "name": "Lance_Enemy_Combatant",
+      "encounterObject": {
+        "EncounterObjectGuid": "f426f0dc-969d-477d-81a9-d02f9e1eff79"
+      }
+    }
+  ],
+  "dialogueList": [
+    {
+      "dialogue": {
+        "EncounterObjectGuid": "73df8d9c-a274-48fd-98c9-2bd0d7860e83"
+      },
+      "name": "Dialogue_MissionStart",
+      "overrideDialogueBucketId": "",
+      "dialogueContent": [
+        {
+          "words": "Here we go, Commander.",
+          "wordsColor": {
+            "r": 1,
+            "g": 1,
+            "b": 1,
+            "a": 1
+          },
+          "selectedCastDefId": "castDef_DariusDefault",
+          "emote": "Default",
+          "audioName": "NONE",
+          "cameraFocusGuid": "",
+          "cameraDistance": "Far",
+          "cameraHeight": "Default",
+          "revealRadius": -1
+        },
+        {
+          "words": "All the holo-cams are focused on you guys so put up a show but finish that {TEAM_TAR.FactionDef.Demonym} champion in style.",
+          "wordsColor": {
+            "r": 1,
+            "g": 1,
+            "b": 1,
+            "a": 1
+          },
+          "selectedCastDefId": "castDef_DariusDefault",
+          "emote": "Default",
+          "audioName": "NONE",
+          "cameraFocusGuid": "",
+          "cameraDistance": "Far",
+          "cameraHeight": "Default",
+          "revealRadius": -1
+        }
+      ]
+    },
+    {
+      "dialogue": {
+        "EncounterObjectGuid": "4011a4c3-cba2-4d22-b2b3-3b19a3297ab9"
+      },
+      "name": "Dialogue_MissionSuccess",
+      "overrideDialogueBucketId": "",
+      "dialogueContent": [
+        {
+          "words": "Good job, Commander! That should put to rest any doubts on our skill.",
+          "wordsColor": {
+            "r": 1,
+            "g": 1,
+            "b": 1,
+            "a": 1
+          },
+          "selectedCastDefId": "castDef_DariusDefault",
+          "emote": "Default",
+          "audioName": "NONE",
+          "cameraFocusGuid": "",
+          "cameraDistance": "Far",
+          "cameraHeight": "Default",
+          "revealRadius": -1
+        }
+      ]
+    },
+    {
+      "dialogue": {
+        "EncounterObjectGuid": "d3d33d95-9ed7-4686-b9eb-954ebe51cc02"
+      },
+      "name": "Dialogue_MissionFailure",
+      "overrideDialogueBucketId": "",
+      "dialogueContent": [
+        {
+          "words": "Well... at least we didn't go down without a fight. Let's hope the holo-cams got your good side, Commander.",
+          "wordsColor": {
+            "r": 1,
+            "g": 1,
+            "b": 1,
+            "a": 1
+          },
+          "selectedCastDefId": "castDef_DariusDefault",
+          "emote": "Default",
+          "audioName": "NONE",
+          "cameraFocusGuid": "",
+          "cameraDistance": "Far",
+          "cameraHeight": "Default",
+          "revealRadius": -1
+        }
+      ]
+    }
+  ],
+  "extractionOverrideList": [],
+  "overwriteMissionCompleteWhenAutoComplete": true,
+  "overrideAutoCompleteDialogueId": null,
+  "disableNegotations": false,
+  "disableLanceConfiguration": false,
+  "disableCancelButton": false,
+  "disableAfterAction": false,
+  "contractRewardOverride": -1,
+  "travelOnly": false,
+  "useTravelCostPenalty": false,
+  "usesExpiration": false,
+  "expirationTimeOverride": -1,
+  "negotiatedSalary": 1,
+  "negotiatedSalvage": 0,
+  "excludedFromProceduralGeneration": false,
+  "player1Team": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "bf40fd39-ccf9-47c4-94a6-061809681140",
+    "teamName": "Player 1",
+    "faction": "Player1sMercUnit",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": [
+      {
+        "lanceSpawner": {
+          "EncounterObjectGuid": "76b654a6-4f2c-4a6f-86e6-d4cf868335fe"
+        },
+        "name": "Spawner_PlayerLance",
+        "lanceDefId": "Manual",
+        "lanceTagSet": {
+          "items": [],
+          "tagSetSourceFile": "tags/LanceTags"
+        },
+        "lanceExcludedTagSet": {
+          "items": [],
+          "tagSetSourceFile": "tags/LanceTags"
+        },
+        "spawnEffectTags": {
+          "items": [],
+          "tagSetSourceFile": "tags/SpawnEffectTags"
+        },
+        "lanceDifficultyAdjustment": 0,
+        "selectedLanceDefId": null,
+        "selectedLanceDifficulty": 0,
+        "unitSpawnPointOverrideList": [
+          {
+            "unitSpawnPoint": {
+              "EncounterObjectGuid": "ec9d2280-ca9a-4d90-8a20-963d8a4c0a39"
+            },
+            "customUnitName": null,
+            "customHeraldryDefId": null,
+            "unitType": "Mech",
+            "unitDefId": "mechDef_None",
+            "unitTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/UnitTags"
+            },
+            "unitExcludedTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/UnitTags"
+            },
+            "spawnEffectTags": {
+              "items": [],
+              "tagSetSourceFile": "tags/SpawnEffectTags"
+            },
+            "pilotDefId": "pilotDef_InheritLance",
+            "pilotTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/PilotTags"
+            },
+            "pilotExcludedTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/PilotTags"
+            },
+            "selectedUnitType": "UNDEFINED",
+            "selectedUnitDefId": null,
+            "selectedPilotDefId": null
+          }
+        ]
+      }
+    ]
+  },
+  "player2Team": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "757173dd-b4e1-4bb5-9bee-d78e623cc867",
+    "teamName": "Player 2",
+    "faction": "Player2sMercUnit",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "employerTeam": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "ecc8d4f2-74b4-465d-adf6-84445e5dfc230",
+    "teamName": "Employer",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "targetTeam": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "be77cadd-e245-4240-a93e-b99cc98902a5",
+    "teamName": "Target",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": [
+      {
+        "lanceSpawner": {
+          "EncounterObjectGuid": "f426f0dc-969d-477d-81a9-d02f9e1eff79"
+        },
+        "name": "Lance_Enemy_Champion",
+        "lanceDefId": "Tagged",
+        "lanceTagSet": {
+          "items": ["lance_type_assault", "lance_type_mech"],
+          "tagSetSourceFile": "tags/LanceTags"
+        },
+        "lanceExcludedTagSet": {
+          "items": [],
+          "tagSetSourceFile": "tags/LanceTags"
+        },
+        "spawnEffectTags": {
+          "items": [],
+          "tagSetSourceFile": "tags/SpawnEffectTags"
+        },
+        "lanceDifficultyAdjustment": 2,
+        "selectedLanceDefId": "",
+        "selectedLanceDifficulty": 0,
+        "unitSpawnPointOverrideList": [
+          {
+            "unitSpawnPoint": {
+              "EncounterObjectGuid": "6cd3107e-0f9d-4809-ab8c-fb30faf4cd80"
+            },
+            "customUnitName": "Champion",
+            "customHeraldryDefId": "",
+            "unitType": "Mech",
+            "unitDefId": "mechDef_InheritLance",
+            "unitTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/UnitTags"
+            },
+            "unitExcludedTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/UnitTags"
+            },
+            "spawnEffectTags": {
+              "items": [],
+              "tagSetSourceFile": "tags/SpawnEffectTags"
+            },
+            "pilotDefId": "pilotDef_InheritLance",
+            "pilotTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/PilotTags"
+            },
+            "pilotExcludedTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/PilotTags"
+            },
+            "selectedUnitType": "UNDEFINED",
+            "selectedUnitDefId": "",
+            "selectedPilotDefId": ""
+          }
+        ]
+      }
+    ]
+  },
+  "targetsAllyTeam": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "31151ed6-cfc2-467e-98c4-9ae5bea784cf",
+    "teamName": "Target's Ally",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "neutralToAllTeam": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "61612bb3-abf9-4586-952a-0559fa9dcd75",
+    "teamName": "Neutral to All",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "hostileToAllTeam": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "3c9f3a20-ab03-4bcb-8ab6-b1ef0442bbf0",
+    "teamName": "Hostile to All",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "employersAllyTeam": {
+    "encounterLayerData": null,
+    "teamGuid": "70af7e7f-39a8-4e81-87c2-bd01dcb01b5e",
+    "teamName": "Employers Ally",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "contractTypeID": "SoloDuel"
+}

--- a/Flashpoint DLC Flashpoints/contracts/heroduel/SoloDuel_ChallengeAccepted.json
+++ b/Flashpoint DLC Flashpoints/contracts/heroduel/SoloDuel_ChallengeAccepted.json
@@ -1,0 +1,411 @@
+{
+  "ID": "SoloDuel_ChallengeAccepted",
+  "contractName": "Challenge Accepted",
+  "contractDisplayStyle": "BaseCampaignNormal",
+  "difficulty": 2,
+  "difficultyUIModifier": 0,
+  "weight": 1,
+  "scope": "STANDARD",
+  "finalDifficulty": 0,
+  "representativeCastDefIDOverride": null,
+  "missionSuccessStatementOverride": null,
+  "badFaithStatementOverride": null,
+  "goodFaithStatementOverride": null,
+  "shortDescription": "Over the past few weeks we've been engaged in small stage skirmishes with {TEAM_TAR.FactionDef.ShortName} in and around {TGT_SYSTEM.name}. The company commander must feel they can't continue their campaign because they've requested a duel to claim this local forward base. Little do they know that we've recently run out of supplies so we've very much taken them up on their offer. This is where you come in. We need to you win this for us, Commander.",
+  "longDescription": "No ammo left? What kind of idiot set up their supply lines. Let's clean this duel up and cash in, Commander.",
+  "salvagePotential": 2,
+  "requirementList": [
+    {
+      "Scope": "StarSystem",
+      "RequirementTags": {
+        "items": [],
+        "tagSetSourceFile": ""
+      },
+      "ExclusionTags": {
+        "items": [],
+        "tagSetSourceFile": ""
+      },
+      "RequirementComparisons": [
+        {
+          "obj": "Employer.IsOwner",
+          "op": "Equal",
+          "val": 1,
+          "valueConstant": null
+        }
+      ]
+    }
+  ],
+  "OnContractSuccessResults": [],
+  "OnContractFailureResults": [],
+  "encounterPlayStyle": "SinglePlayer",
+  "maxNumberOfPlayerUnits": 1,
+  "lanceMinTonnage": -1,
+  "lanceMaxTonnage": -1,
+  "mechMinTonnages": [-1, -1, -1, -1],
+  "mechMaxTonnages": [35, -1, -1, -1],
+  "mapMood": null,
+  "startingFogOfWarVisibility": "Surveyed",
+  "contractObjectiveList": [
+    {
+      "contractObjective": {
+        "EncounterObjectGuid": "73275787-720a-4c33-9f20-953b1bbf48bd"
+      },
+      "title": "Save the forward base",
+      "description": "",
+      "isPrimary": true,
+      "forPlayer": "Player1",
+      "objectiveGuids": ["a0b9c5b2-c594-4c5a-be1d-028a51c51519"]
+    }
+  ],
+  "objectiveList": [
+    {
+      "objective": {
+        "EncounterObjectGuid": "a0b9c5b2-c594-4c5a-be1d-028a51c51519"
+      },
+      "title": "Destroy Duelist Commander",
+      "description": "",
+      "isPrimary": true,
+      "OnSuccessResults": [],
+      "OnFailureResults": [],
+      "OnSuccessDialogueGUID": null,
+      "OnFailureDialogueGUID": null
+    }
+  ],
+  "artilleryObjectiveList": [],
+  "buildingList": [],
+  "chunkList": [
+    {
+      "name": "Chunk_SwapSpawnerPlacement",
+      "encounterChunk": {
+        "EncounterObjectGuid": "ed007c52-f4cb-4bfc-842a-a50454d8a82a"
+      },
+      "enableChunkFromContract": false
+    }
+  ],
+  "cameraFocusHelperList": [
+    {
+      "name": "Spawner_PlayerLance",
+      "encounterObject": {
+        "EncounterObjectGuid": "76b654a6-4f2c-4a6f-86e6-d4cf868335fe"
+      }
+    },
+    {
+      "name": "Lance_Enemy_Combatant",
+      "encounterObject": {
+        "EncounterObjectGuid": "f426f0dc-969d-477d-81a9-d02f9e1eff79"
+      }
+    }
+  ],
+  "dialogueList": [
+    {
+      "dialogue": {
+        "EncounterObjectGuid": "73df8d9c-a274-48fd-98c9-2bd0d7860e83"
+      },
+      "name": "Dialogue_MissionStart",
+      "overrideDialogueBucketId": "",
+      "dialogueContent": [
+        {
+          "words": "That's the one, Commander. Take him out.",
+          "wordsColor": {
+            "r": 1,
+            "g": 1,
+            "b": 1,
+            "a": 1
+          },
+          "selectedCastDefId": "castDef_DariusDefault",
+          "emote": "Default",
+          "audioName": "NONE",
+          "cameraFocusGuid": "",
+          "cameraDistance": "Far",
+          "cameraHeight": "Default",
+          "revealRadius": -1
+        }
+      ]
+    },
+    {
+      "dialogue": {
+        "EncounterObjectGuid": "4011a4c3-cba2-4d22-b2b3-3b19a3297ab9"
+      },
+      "name": "Dialogue_MissionSuccess",
+      "overrideDialogueBucketId": "",
+      "dialogueContent": [
+        {
+          "words": "Done and done. Great job, Commander. Let's go home.",
+          "wordsColor": {
+            "r": 1,
+            "g": 1,
+            "b": 1,
+            "a": 1
+          },
+          "selectedCastDefId": "castDef_DariusDefault",
+          "emote": "Default",
+          "audioName": "NONE",
+          "cameraFocusGuid": "",
+          "cameraDistance": "Far",
+          "cameraHeight": "Default",
+          "revealRadius": -1
+        }
+      ]
+    },
+    {
+      "dialogue": {
+        "EncounterObjectGuid": "d3d33d95-9ed7-4686-b9eb-954ebe51cc02"
+      },
+      "name": "Dialogue_MissionFailure",
+      "overrideDialogueBucketId": "",
+      "dialogueContent": [
+        {
+          "words": "We're coming in to pick you up fast, Commander. Hold on. We'll sort out the polical fallout from this later.",
+          "wordsColor": {
+            "r": 1,
+            "g": 1,
+            "b": 1,
+            "a": 1
+          },
+          "selectedCastDefId": "castDef_DariusDefault",
+          "emote": "Default",
+          "audioName": "NONE",
+          "cameraFocusGuid": "",
+          "cameraDistance": "Far",
+          "cameraHeight": "Default",
+          "revealRadius": -1
+        }
+      ]
+    },
+    {
+      "dialogue": {
+        "EncounterObjectGuid": "8971ddc6-a882-4066-923f-f8be03450ce2"
+      },
+      "name": "Dialogue_DuelTaunt",
+      "overrideDialogueBucketId": "",
+      "dialogueContent": [
+        {
+          "words": "I know they said they were going to send a proxy but, a lowly Merc? What a waste of a perfectly good duel.",
+          "wordsColor": {
+            "r": 1,
+            "g": 1,
+            "b": 1,
+            "a": 1
+          },
+          "selectedCastDefId": "castDef_TeamLeader_Current",
+          "emote": "Default",
+          "audioName": "NONE",
+          "cameraFocusGuid": "f426f0dc-969d-477d-81a9-d02f9e1eff79",
+          "cameraDistance": "Close",
+          "cameraHeight": "Default",
+          "revealRadius": -1
+        }
+      ]
+    }
+  ],
+  "extractionOverrideList": [],
+  "overwriteMissionCompleteWhenAutoComplete": true,
+  "overrideAutoCompleteDialogueId": null,
+  "disableNegotations": false,
+  "disableLanceConfiguration": false,
+  "disableCancelButton": false,
+  "disableAfterAction": false,
+  "contractRewardOverride": -1,
+  "travelOnly": false,
+  "useTravelCostPenalty": false,
+  "usesExpiration": false,
+  "expirationTimeOverride": -1,
+  "negotiatedSalary": 1,
+  "negotiatedSalvage": 0,
+  "excludedFromProceduralGeneration": false,
+  "player1Team": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "bf40fd39-ccf9-47c4-94a6-061809681140",
+    "teamName": "Player 1",
+    "faction": "Player1sMercUnit",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": [
+      {
+        "lanceSpawner": {
+          "EncounterObjectGuid": "76b654a6-4f2c-4a6f-86e6-d4cf868335fe"
+        },
+        "name": "Spawner_PlayerLance",
+        "lanceDefId": "Manual",
+        "lanceTagSet": {
+          "items": [],
+          "tagSetSourceFile": "tags/LanceTags"
+        },
+        "lanceExcludedTagSet": {
+          "items": [],
+          "tagSetSourceFile": "tags/LanceTags"
+        },
+        "spawnEffectTags": {
+          "items": [],
+          "tagSetSourceFile": "tags/SpawnEffectTags"
+        },
+        "lanceDifficultyAdjustment": 0,
+        "selectedLanceDefId": null,
+        "selectedLanceDifficulty": 0,
+        "unitSpawnPointOverrideList": [
+          {
+            "unitSpawnPoint": {
+              "EncounterObjectGuid": "ec9d2280-ca9a-4d90-8a20-963d8a4c0a39"
+            },
+            "customUnitName": null,
+            "customHeraldryDefId": null,
+            "unitType": "Mech",
+            "unitDefId": "mechDef_None",
+            "unitTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/UnitTags"
+            },
+            "unitExcludedTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/UnitTags"
+            },
+            "spawnEffectTags": {
+              "items": [],
+              "tagSetSourceFile": "tags/SpawnEffectTags"
+            },
+            "pilotDefId": "pilotDef_InheritLance",
+            "pilotTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/PilotTags"
+            },
+            "pilotExcludedTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/PilotTags"
+            },
+            "selectedUnitType": "UNDEFINED",
+            "selectedUnitDefId": null,
+            "selectedPilotDefId": null
+          }
+        ]
+      }
+    ]
+  },
+  "player2Team": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "757173dd-b4e1-4bb5-9bee-d78e623cc867",
+    "teamName": "Player 2",
+    "faction": "Player2sMercUnit",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "employerTeam": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "ecc8d4f2-74b4-465d-adf6-84445e5dfc230",
+    "teamName": "Employer",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "targetTeam": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "be77cadd-e245-4240-a93e-b99cc98902a5",
+    "teamName": "Target",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": [
+      {
+        "lanceSpawner": {
+          "EncounterObjectGuid": "f426f0dc-969d-477d-81a9-d02f9e1eff79"
+        },
+        "name": "Lance_Enemy_Champion",
+        "lanceDefId": "Tagged",
+        "lanceTagSet": {
+          "items": ["lance_type_light", "lance_type_mech"],
+          "tagSetSourceFile": "tags/LanceTags"
+        },
+        "lanceExcludedTagSet": {
+          "items": [],
+          "tagSetSourceFile": "tags/LanceTags"
+        },
+        "spawnEffectTags": {
+          "items": [],
+          "tagSetSourceFile": "tags/SpawnEffectTags"
+        },
+        "lanceDifficultyAdjustment": 2,
+        "selectedLanceDefId": "",
+        "selectedLanceDifficulty": 0,
+        "unitSpawnPointOverrideList": [
+          {
+            "unitSpawnPoint": {
+              "EncounterObjectGuid": "6cd3107e-0f9d-4809-ab8c-fb30faf4cd80"
+            },
+            "customUnitName": "Commander",
+            "customHeraldryDefId": "",
+            "unitType": "Mech",
+            "unitDefId": "mechDef_InheritLance",
+            "unitTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/UnitTags"
+            },
+            "unitExcludedTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/UnitTags"
+            },
+            "spawnEffectTags": {
+              "items": [],
+              "tagSetSourceFile": "tags/SpawnEffectTags"
+            },
+            "pilotDefId": "pilotDef_InheritLance",
+            "pilotTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/PilotTags"
+            },
+            "pilotExcludedTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/PilotTags"
+            },
+            "selectedUnitType": "UNDEFINED",
+            "selectedUnitDefId": "",
+            "selectedPilotDefId": ""
+          }
+        ]
+      }
+    ]
+  },
+  "targetsAllyTeam": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "31151ed6-cfc2-467e-98c4-9ae5bea784cf",
+    "teamName": "Target's Ally",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "neutralToAllTeam": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "61612bb3-abf9-4586-952a-0559fa9dcd75",
+    "teamName": "Neutral to All",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "hostileToAllTeam": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "3c9f3a20-ab03-4bcb-8ab6-b1ef0442bbf0",
+    "teamName": "Hostile to All",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "employersAllyTeam": {
+    "encounterLayerData": null,
+    "teamGuid": "70af7e7f-39a8-4e81-87c2-bd01dcb01b5e",
+    "teamName": "Employers Ally",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "contractTypeID": "SoloDuel"
+}

--- a/Flashpoint DLC Flashpoints/contracts/heroduel/SoloDuel_ChipOnTheShoulder.json
+++ b/Flashpoint DLC Flashpoints/contracts/heroduel/SoloDuel_ChipOnTheShoulder.json
@@ -1,0 +1,409 @@
+{
+  "ID" : "SoloDuel_ChipOnTheShoulder",
+  "contractName" : "Chip On The Shoulder",
+  "contractDisplayStyle" : "BaseCampaignNormal",
+  "difficulty" : 8,
+  "difficultyUIModifier" : 0,
+  "weight" : 1,
+  "scope" : "STANDARD",
+  "finalDifficulty" : 0,
+  "representativeCastDefIDOverride" : null,
+  "missionSuccessStatementOverride" : null,
+  "badFaithStatementOverride" : null,
+  "goodFaithStatementOverride" : null,
+  "shortDescription" : "An out of favor {TEAM_TAR.FactionDef.Demonym} MechWarrior has issued us a challenge in order to curry favor with their superiors. Our employer wants them shut down to help curb these kinds of random challenges in the future. Sounds like easy money to me.",
+  "longDescription" : "Commander, this seems like a straight up duel. It's based in an established arena so I guess it's as good as we'll get to 'safe'.",
+  "salvagePotential" : 4,
+  "requirementList" : [
+      {
+        "Scope" : "StarSystem",
+        "RequirementTags" : {
+            "items" : [],
+            "tagSetSourceFile" : ""
+        },
+        "ExclusionTags" : {
+            "items" : [],
+            "tagSetSourceFile" : ""
+        },
+        "RequirementComparisons" : []
+      }
+  ],
+  "OnContractSuccessResults" : [],
+  "OnContractFailureResults" : [],
+  "encounterPlayStyle" : "SinglePlayer",
+  "maxNumberOfPlayerUnits" : 1,
+  "lanceMinTonnage" : -1,
+  "lanceMaxTonnage" : -1,
+  "mechMinTonnages" : [
+      -1,
+      -1,
+      -1,
+      -1
+  ],
+  "mechMaxTonnages" : [
+      -1,
+      -1,
+      -1,
+      -1
+  ],
+  "mapMood" : null,
+  "startingFogOfWarVisibility" : "Surveyed",
+  "contractObjectiveList" : [
+      {
+          "contractObjective" : {
+              "EncounterObjectGuid" : "73275787-720a-4c33-9f20-953b1bbf48bd"
+          },
+          "title" : "Overcome the mechwarrior",
+          "description" : "",
+          "isPrimary" : true,
+          "forPlayer" : "Player1",
+          "objectiveGuids" : [
+              "a0b9c5b2-c594-4c5a-be1d-028a51c51519"
+          ]
+      }
+  ],
+  "objectiveList" : [
+      {
+          "objective" : {
+              "EncounterObjectGuid" : "a0b9c5b2-c594-4c5a-be1d-028a51c51519"
+          },
+          "title" : "Destroy Enemy MechWarrior",
+          "description" : "",
+          "isPrimary" : true,
+          "OnSuccessResults" : [],
+          "OnFailureResults" : [],
+          "OnSuccessDialogueGUID" : null,
+          "OnFailureDialogueGUID" : null
+      }
+  ],
+  "artilleryObjectiveList" : [],
+  "buildingList" : [],
+  "chunkList" : [
+    {
+      "name" : "Chunk_SwapSpawnerPlacement",
+      "encounterChunk" : {
+        "EncounterObjectGuid" : "ed007c52-f4cb-4bfc-842a-a50454d8a82a"
+      },
+      "enableChunkFromContract" : true
+    }
+  ],
+  "cameraFocusHelperList" : [
+      {
+          "name" : "Spawner_PlayerLance",
+          "encounterObject" : {
+              "EncounterObjectGuid" : "76b654a6-4f2c-4a6f-86e6-d4cf868335fe"
+          }
+      },
+      {
+          "name" : "Lance_Enemy_Combatant",
+          "encounterObject" : {
+              "EncounterObjectGuid" : "f426f0dc-969d-477d-81a9-d02f9e1eff79"
+          }
+      }
+  ],
+  "dialogueList" : [
+      {
+          "dialogue" : {
+              "EncounterObjectGuid" : "73df8d9c-a274-48fd-98c9-2bd0d7860e83"
+          },
+          "name" : "Dialogue_MissionStart",
+          "overrideDialogueBucketId" : "",
+          "dialogueContent" : [
+              {
+                  "words" : "Here we go, Commander.",
+                  "wordsColor" : {
+                      "r" : 1,
+                      "g" : 1,
+                      "b" : 1,
+                      "a" : 1
+                  },
+                  "selectedCastDefId" : "castDef_DariusDefault",
+                  "emote" : "Default",
+                  "audioName" : "NONE",
+                  "cameraFocusGuid" : "",
+                  "cameraDistance" : "Far",
+                  "cameraHeight" : "Default",
+                  "revealRadius" : -1
+              },
+              {
+                  "words" : "Put that rundown {TEAM_TAR.FactionDef.Demonym} MechWarrior down, Commander.",
+                  "wordsColor" : {
+                      "r" : 1,
+                      "g" : 1,
+                      "b" : 1,
+                      "a" : 1
+                  },
+                  "selectedCastDefId" : "castDef_DariusDefault",
+                  "emote" : "Default",
+                  "audioName" : "NONE",
+                  "cameraFocusGuid" : "",
+                  "cameraDistance" : "Far",
+                  "cameraHeight" : "Default",
+                  "revealRadius" : -1
+              }
+          ]
+      },
+      {
+          "dialogue" : {
+              "EncounterObjectGuid" : "4011a4c3-cba2-4d22-b2b3-3b19a3297ab9"
+          },
+          "name" : "Dialogue_MissionSuccess",
+          "overrideDialogueBucketId" : "",
+          "dialogueContent" : [
+              {
+                  "words" : "Good job, Commander! That should put to rest any further challenges like this one.",
+                  "wordsColor" : {
+                      "r" : 1,
+                      "g" : 1,
+                      "b" : 1,
+                      "a" : 1
+                  },
+                  "selectedCastDefId" : "castDef_DariusDefault",
+                  "emote" : "Default",
+                  "audioName" : "NONE",
+                  "cameraFocusGuid" : "",
+                  "cameraDistance" : "Far",
+                  "cameraHeight" : "Default",
+                  "revealRadius" : -1
+              }
+          ]
+      },
+      {
+          "dialogue" : {
+              "EncounterObjectGuid" : "d3d33d95-9ed7-4686-b9eb-954ebe51cc02"
+          },
+          "name" : "Dialogue_MissionFailure",
+          "overrideDialogueBucketId" : "",
+          "dialogueContent" : [
+              {
+                  "words" : "Well... at least we didn't go down without a fight.",
+                  "wordsColor" : {
+                      "r" : 1,
+                      "g" : 1,
+                      "b" : 1,
+                      "a" : 1
+                  },
+                  "selectedCastDefId" : "castDef_DariusDefault",
+                  "emote" : "Default",
+                  "audioName" : "NONE",
+                  "cameraFocusGuid" : "",
+                  "cameraDistance" : "Far",
+                  "cameraHeight" : "Default",
+                  "revealRadius" : -1
+              }
+          ]
+      }
+  ],
+  "extractionOverrideList" : [],
+  "overwriteMissionCompleteWhenAutoComplete" : true,
+  "overrideAutoCompleteDialogueId" : null,
+  "disableNegotations" : false,
+  "disableLanceConfiguration" : false,
+  "disableCancelButton" : false,
+  "disableAfterAction" : false,
+  "contractRewardOverride" : -1,
+  "travelOnly" : false,
+  "useTravelCostPenalty" : false,
+  "usesExpiration" : false,
+  "expirationTimeOverride" : -1,
+  "negotiatedSalary" : 1,
+  "negotiatedSalvage" : 0,
+  "excludedFromProceduralGeneration" : false,
+  "player1Team" : {
+      "encounterLayerData" : {
+          "EncounterObjectGuid" : "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+      },
+      "teamGuid" : "bf40fd39-ccf9-47c4-94a6-061809681140",
+      "teamName" : "Player 1",
+      "faction" : "Player1sMercUnit",
+      "teamLeaderCastDefId" : "castDef_TeamLeader_Current",
+      "lanceOverrideList" : [
+          {
+              "lanceSpawner" : {
+                  "EncounterObjectGuid" : "76b654a6-4f2c-4a6f-86e6-d4cf868335fe"
+              },
+              "name" : "Spawner_PlayerLance",
+              "lanceDefId" : "Manual",
+              "lanceTagSet" : {
+                  "items" : [],
+                  "tagSetSourceFile" : "tags/LanceTags"
+              },
+              "lanceExcludedTagSet" : {
+                  "items" : [],
+                  "tagSetSourceFile" : "tags/LanceTags"
+              },
+              "spawnEffectTags" : {
+                  "items" : [],
+                  "tagSetSourceFile" : "tags/SpawnEffectTags"
+              },
+              "lanceDifficultyAdjustment" : 0,
+              "selectedLanceDefId" : null,
+              "selectedLanceDifficulty" : 0,
+              "unitSpawnPointOverrideList" : [
+                  {
+                      "unitSpawnPoint" : {
+                          "EncounterObjectGuid" : "ec9d2280-ca9a-4d90-8a20-963d8a4c0a39"
+                      },
+                      "customUnitName" : null,
+                      "customHeraldryDefId" : null,
+                      "unitType" : "Mech",
+                      "unitDefId" : "mechDef_None",
+                      "unitTagSet" : {
+                          "items" : [],
+                          "tagSetSourceFile" : "tags/UnitTags"
+                      },
+                      "unitExcludedTagSet" : {
+                          "items" : [],
+                          "tagSetSourceFile" : "tags/UnitTags"
+                      },
+                      "spawnEffectTags" : {
+                          "items" : [],
+                          "tagSetSourceFile" : "tags/SpawnEffectTags"
+                      },
+                      "pilotDefId" : "pilotDef_InheritLance",
+                      "pilotTagSet" : {
+                          "items" : [],
+                          "tagSetSourceFile" : "tags/PilotTags"
+                      },
+                      "pilotExcludedTagSet" : {
+                          "items" : [],
+                          "tagSetSourceFile" : "tags/PilotTags"
+                      },
+                      "selectedUnitType" : "UNDEFINED",
+                      "selectedUnitDefId" : null,
+                      "selectedPilotDefId" : null
+                  }
+              ]
+          }
+      ]
+  },
+  "player2Team" : {
+      "encounterLayerData" : {
+          "EncounterObjectGuid" : "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+      },
+      "teamGuid" : "757173dd-b4e1-4bb5-9bee-d78e623cc867",
+      "teamName" : "Player 2",
+      "faction" : "Player2sMercUnit",
+      "teamLeaderCastDefId" : "castDef_TeamLeader_Current",
+      "lanceOverrideList" : []
+  },
+  "employerTeam" : {
+      "encounterLayerData" : {
+          "EncounterObjectGuid" : "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+      },
+      "teamGuid" : "ecc8d4f2-74b4-465d-adf6-84445e5dfc230",
+      "teamName" : "Employer",
+      "faction" : "INVALID_UNSET",
+      "teamLeaderCastDefId" : "castDef_TeamLeader_Current",
+      "lanceOverrideList" : []
+  },
+  "targetTeam" : {
+      "encounterLayerData" : {
+          "EncounterObjectGuid" : "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+      },
+      "teamGuid" : "be77cadd-e245-4240-a93e-b99cc98902a5",
+      "teamName" : "Target",
+      "faction" : "INVALID_UNSET",
+      "teamLeaderCastDefId" : "castDef_TeamLeader_Current",
+      "lanceOverrideList" : [
+        {
+          "lanceSpawner" : {
+              "EncounterObjectGuid" : "f426f0dc-969d-477d-81a9-d02f9e1eff79"
+          },
+          "name" : "Lance_Enemy_Champion",
+          "lanceDefId" : "Tagged",
+          "lanceTagSet" : {
+              "items" : [
+                "lance_type_solo"
+              ],
+              "tagSetSourceFile" : "tags/LanceTags"
+          },
+          "lanceExcludedTagSet" : {
+              "items" : [],
+              "tagSetSourceFile" : "tags/LanceTags"
+          },
+          "spawnEffectTags" : {
+              "items" : [],
+              "tagSetSourceFile" : "tags/SpawnEffectTags"
+          },
+          "lanceDifficultyAdjustment" : 2,
+          "selectedLanceDefId" : "",
+          "selectedLanceDifficulty" : 0,
+          "unitSpawnPointOverrideList" : [
+              {
+                  "unitSpawnPoint" : {
+                      "EncounterObjectGuid" : "6cd3107e-0f9d-4809-ab8c-fb30faf4cd80"
+                  },
+                  "customUnitName" : "Champion",
+                  "customHeraldryDefId" : "",
+                  "unitType" : "Mech",
+                  "unitDefId" : "mechDef_InheritLance",
+                  "unitTagSet" : {
+                      "items" : [],
+                      "tagSetSourceFile" : "tags/UnitTags"
+                  },
+                  "unitExcludedTagSet" : {
+                      "items" : [],
+                      "tagSetSourceFile" : "tags/UnitTags"
+                  },
+                  "spawnEffectTags" : {
+                      "items" : [],
+                      "tagSetSourceFile" : "tags/SpawnEffectTags"
+                  },
+                  "pilotDefId" : "pilotDef_InheritLance",
+                  "pilotTagSet" : {
+                      "items" : [],
+                      "tagSetSourceFile" : "tags/PilotTags"
+                  },
+                  "pilotExcludedTagSet" : {
+                      "items" : [],
+                      "tagSetSourceFile" : "tags/PilotTags"
+                  },
+                  "selectedUnitType" : "UNDEFINED",
+                  "selectedUnitDefId" : "",
+                  "selectedPilotDefId" : ""
+              }
+          ]
+      }
+      ]
+  },
+  "targetsAllyTeam" : {
+      "encounterLayerData" : {
+          "EncounterObjectGuid" : "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+      },
+      "teamGuid" : "31151ed6-cfc2-467e-98c4-9ae5bea784cf",
+      "teamName" : "Target's Ally",
+      "faction" : "INVALID_UNSET",
+      "teamLeaderCastDefId" : "castDef_TeamLeader_Current",
+      "lanceOverrideList" : []
+  },
+  "neutralToAllTeam" : {
+      "encounterLayerData" : {
+          "EncounterObjectGuid" : "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+      },
+      "teamGuid" : "61612bb3-abf9-4586-952a-0559fa9dcd75",
+      "teamName" : "Neutral to All",
+      "faction" : "INVALID_UNSET",
+      "teamLeaderCastDefId" : "castDef_TeamLeader_Current",
+      "lanceOverrideList" : []
+  },
+  "hostileToAllTeam" : {
+      "encounterLayerData" : {
+          "EncounterObjectGuid" : "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+      },
+      "teamGuid" : "3c9f3a20-ab03-4bcb-8ab6-b1ef0442bbf0",
+      "teamName" : "Hostile to All",
+      "faction" : "INVALID_UNSET",
+      "teamLeaderCastDefId" : "castDef_TeamLeader_Current",
+      "lanceOverrideList" : []
+  },
+  "employersAllyTeam" : {
+      "encounterLayerData" : null,
+      "teamGuid" : "70af7e7f-39a8-4e81-87c2-bd01dcb01b5e",
+      "teamName" : "Employers Ally",
+      "faction" : "INVALID_UNSET",
+      "teamLeaderCastDefId" : "castDef_TeamLeader_Current",
+      "lanceOverrideList" : []
+  },
+  "contractTypeID" : "SoloDuel"
+}

--- a/Flashpoint DLC Flashpoints/contracts/heroduel/SoloDuel_CorneredRevenge.json
+++ b/Flashpoint DLC Flashpoints/contracts/heroduel/SoloDuel_CorneredRevenge.json
@@ -1,0 +1,411 @@
+{
+  "ID": "SoloDuel_CorneredRevenge",
+  "contractName": "Cornered Revenge",
+  "contractDisplayStyle": "BaseCampaignNormal",
+  "difficulty": 5,
+  "difficultyUIModifier": 0,
+  "weight": 1,
+  "scope": "STANDARD",
+  "finalDifficulty": 0,
+  "representativeCastDefIDOverride": null,
+  "missionSuccessStatementOverride": null,
+  "badFaithStatementOverride": null,
+  "goodFaithStatementOverride": null,
+  "shortDescription": "We have a BattleMech causing us trouble in {TGT_SYSTEM.name} who refuses to backdown until you, Commander, show up and fight them in a duel. They call themselves Killbox. I don't know what their problem is with you but we'll pay you to get here and just deal with them. It's causing us a headache.",
+  "longDescription": "'Killbox'? Haven't heard that name for a long time. Do you think she's still upset after all these years?",
+  "salvagePotential": 3,
+  "requirementList": [
+    {
+      "Scope": "StarSystem",
+      "RequirementTags": {
+        "items": [],
+        "tagSetSourceFile": ""
+      },
+      "ExclusionTags": {
+        "items": [],
+        "tagSetSourceFile": ""
+      },
+      "RequirementComparisons": [
+        {
+          "obj": "Employer.IsOwner",
+          "op": "Equal",
+          "val": 1,
+          "valueConstant": null
+        }
+      ]
+    }
+  ],
+  "OnContractSuccessResults": [],
+  "OnContractFailureResults": [],
+  "encounterPlayStyle": "SinglePlayer",
+  "maxNumberOfPlayerUnits": 1,
+  "lanceMinTonnage": -1,
+  "lanceMaxTonnage": -1,
+  "mechMinTonnages": [-1, -1, -1, -1],
+  "mechMaxTonnages": [65, -1, -1, -1],
+  "mapMood": null,
+  "startingFogOfWarVisibility": "Surveyed",
+  "contractObjectiveList": [
+    {
+      "contractObjective": {
+        "EncounterObjectGuid": "73275787-720a-4c33-9f20-953b1bbf48bd"
+      },
+      "title": "Defeat the Killbox",
+      "description": "",
+      "isPrimary": true,
+      "forPlayer": "Player1",
+      "objectiveGuids": ["a0b9c5b2-c594-4c5a-be1d-028a51c51519"]
+    }
+  ],
+  "objectiveList": [
+    {
+      "objective": {
+        "EncounterObjectGuid": "a0b9c5b2-c594-4c5a-be1d-028a51c51519"
+      },
+      "title": "Defeat Killbox",
+      "description": "",
+      "isPrimary": true,
+      "OnSuccessResults": [],
+      "OnFailureResults": [],
+      "OnSuccessDialogueGUID": null,
+      "OnFailureDialogueGUID": null
+    }
+  ],
+  "artilleryObjectiveList": [],
+  "buildingList": [],
+  "chunkList": [
+    {
+      "name": "Chunk_SwapSpawnerPlacement",
+      "encounterChunk": {
+        "EncounterObjectGuid": "ed007c52-f4cb-4bfc-842a-a50454d8a82a"
+      },
+      "enableChunkFromContract": false
+    }
+  ],
+  "cameraFocusHelperList": [
+    {
+      "name": "Spawner_PlayerLance",
+      "encounterObject": {
+        "EncounterObjectGuid": "76b654a6-4f2c-4a6f-86e6-d4cf868335fe"
+      }
+    },
+    {
+      "name": "Lance_Enemy_Combatant",
+      "encounterObject": {
+        "EncounterObjectGuid": "f426f0dc-969d-477d-81a9-d02f9e1eff79"
+      }
+    }
+  ],
+  "dialogueList": [
+    {
+      "dialogue": {
+        "EncounterObjectGuid": "73df8d9c-a274-48fd-98c9-2bd0d7860e83"
+      },
+      "name": "Dialogue_MissionStart",
+      "overrideDialogueBucketId": "",
+      "dialogueContent": [
+        {
+          "words": "Last time we saw Killbox she was stuck on that moon, Commander. Not sure how they got off it. Guess it doesn't matter now. Good luck!",
+          "wordsColor": {
+            "r": 1,
+            "g": 1,
+            "b": 1,
+            "a": 1
+          },
+          "selectedCastDefId": "castDef_DariusDefault",
+          "emote": "Default",
+          "audioName": "NONE",
+          "cameraFocusGuid": "",
+          "cameraDistance": "Far",
+          "cameraHeight": "Default",
+          "revealRadius": -1
+        }
+      ]
+    },
+    {
+      "dialogue": {
+        "EncounterObjectGuid": "4011a4c3-cba2-4d22-b2b3-3b19a3297ab9"
+      },
+      "name": "Dialogue_MissionSuccess",
+      "overrideDialogueBucketId": "",
+      "dialogueContent": [
+        {
+          "words": "I'm glad you got out of that in one piece, Commander. Victories like this feel hollow though.",
+          "wordsColor": {
+            "r": 1,
+            "g": 1,
+            "b": 1,
+            "a": 1
+          },
+          "selectedCastDefId": "castDef_DariusDefault",
+          "emote": "Default",
+          "audioName": "NONE",
+          "cameraFocusGuid": "",
+          "cameraDistance": "Far",
+          "cameraHeight": "Default",
+          "revealRadius": -1
+        }
+      ]
+    },
+    {
+      "dialogue": {
+        "EncounterObjectGuid": "d3d33d95-9ed7-4686-b9eb-954ebe51cc02"
+      },
+      "name": "Dialogue_MissionFailure",
+      "overrideDialogueBucketId": "",
+      "dialogueContent": [
+        {
+          "words": "Killbox! We've got our lances incoming to wipe you out if you go any further. Leave now!",
+          "wordsColor": {
+            "r": 1,
+            "g": 1,
+            "b": 1,
+            "a": 1
+          },
+          "selectedCastDefId": "castDef_DariusDefault",
+          "emote": "Default",
+          "audioName": "NONE",
+          "cameraFocusGuid": "",
+          "cameraDistance": "Far",
+          "cameraHeight": "Default",
+          "revealRadius": -1
+        }
+      ]
+    },
+    {
+      "dialogue": {
+        "EncounterObjectGuid": "8971ddc6-a882-4066-923f-f8be03450ce2"
+      },
+      "name": "Dialogue_DuelTaunt",
+      "overrideDialogueBucketId": "",
+      "dialogueContent": [
+        {
+          "words": "Never thought you'd see me again, Commander? You wouldn't if it wasn't for {TEAM_TAR.FactionDef.ShortName} helping me off that forsaken moon. I can't forgive you for what you did. Now... unlike last time - let's finish this once and for all!",
+          "wordsColor": {
+            "r": 1,
+            "g": 1,
+            "b": 1,
+            "a": 1
+          },
+          "selectedCastDefId": "castDef_MC_Killbox",
+          "emote": "Default",
+          "audioName": "NONE",
+          "cameraFocusGuid": "f426f0dc-969d-477d-81a9-d02f9e1eff79",
+          "cameraDistance": "Close",
+          "cameraHeight": "Default",
+          "revealRadius": -1
+        }
+      ]
+    }
+  ],
+  "extractionOverrideList": [],
+  "overwriteMissionCompleteWhenAutoComplete": true,
+  "overrideAutoCompleteDialogueId": null,
+  "disableNegotations": false,
+  "disableLanceConfiguration": false,
+  "disableCancelButton": false,
+  "disableAfterAction": false,
+  "contractRewardOverride": -1,
+  "travelOnly": false,
+  "useTravelCostPenalty": false,
+  "usesExpiration": false,
+  "expirationTimeOverride": -1,
+  "negotiatedSalary": 1,
+  "negotiatedSalvage": 0,
+  "excludedFromProceduralGeneration": false,
+  "player1Team": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "bf40fd39-ccf9-47c4-94a6-061809681140",
+    "teamName": "Player 1",
+    "faction": "Player1sMercUnit",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": [
+      {
+        "lanceSpawner": {
+          "EncounterObjectGuid": "76b654a6-4f2c-4a6f-86e6-d4cf868335fe"
+        },
+        "name": "Spawner_PlayerLance",
+        "lanceDefId": "Manual",
+        "lanceTagSet": {
+          "items": [],
+          "tagSetSourceFile": "tags/LanceTags"
+        },
+        "lanceExcludedTagSet": {
+          "items": [],
+          "tagSetSourceFile": "tags/LanceTags"
+        },
+        "spawnEffectTags": {
+          "items": [],
+          "tagSetSourceFile": "tags/SpawnEffectTags"
+        },
+        "lanceDifficultyAdjustment": 0,
+        "selectedLanceDefId": null,
+        "selectedLanceDifficulty": 0,
+        "unitSpawnPointOverrideList": [
+          {
+            "unitSpawnPoint": {
+              "EncounterObjectGuid": "ec9d2280-ca9a-4d90-8a20-963d8a4c0a39"
+            },
+            "customUnitName": null,
+            "customHeraldryDefId": null,
+            "unitType": "Mech",
+            "unitDefId": "mechDef_None",
+            "unitTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/UnitTags"
+            },
+            "unitExcludedTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/UnitTags"
+            },
+            "spawnEffectTags": {
+              "items": [],
+              "tagSetSourceFile": "tags/SpawnEffectTags"
+            },
+            "pilotDefId": "pilotDef_InheritLance",
+            "pilotTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/PilotTags"
+            },
+            "pilotExcludedTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/PilotTags"
+            },
+            "selectedUnitType": "UNDEFINED",
+            "selectedUnitDefId": null,
+            "selectedPilotDefId": null
+          }
+        ]
+      }
+    ]
+  },
+  "player2Team": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "757173dd-b4e1-4bb5-9bee-d78e623cc867",
+    "teamName": "Player 2",
+    "faction": "Player2sMercUnit",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "employerTeam": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "ecc8d4f2-74b4-465d-adf6-84445e5dfc230",
+    "teamName": "Employer",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "targetTeam": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "be77cadd-e245-4240-a93e-b99cc98902a5",
+    "teamName": "Target",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": [
+      {
+        "lanceSpawner": {
+          "EncounterObjectGuid": "f426f0dc-969d-477d-81a9-d02f9e1eff79"
+        },
+        "name": "Lance_Enemy_Champion",
+        "lanceDefId": "Tagged",
+        "lanceTagSet": {
+          "items": ["lance_type_heavy", "lance_type_mech"],
+          "tagSetSourceFile": "tags/LanceTags"
+        },
+        "lanceExcludedTagSet": {
+          "items": [],
+          "tagSetSourceFile": "tags/LanceTags"
+        },
+        "spawnEffectTags": {
+          "items": [],
+          "tagSetSourceFile": "tags/SpawnEffectTags"
+        },
+        "lanceDifficultyAdjustment": 2,
+        "selectedLanceDefId": "",
+        "selectedLanceDifficulty": 0,
+        "unitSpawnPointOverrideList": [
+          {
+            "unitSpawnPoint": {
+              "EncounterObjectGuid": "6cd3107e-0f9d-4809-ab8c-fb30faf4cd80"
+            },
+            "customUnitName": "Killbox",
+            "customHeraldryDefId": "",
+            "unitType": "Mech",
+            "unitDefId": "mechDef_InheritLance",
+            "unitTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/UnitTags"
+            },
+            "unitExcludedTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/UnitTags"
+            },
+            "spawnEffectTags": {
+              "items": [],
+              "tagSetSourceFile": "tags/SpawnEffectTags"
+            },
+            "pilotDefId": "pilotDef_InheritLance",
+            "pilotTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/PilotTags"
+            },
+            "pilotExcludedTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/PilotTags"
+            },
+            "selectedUnitType": "UNDEFINED",
+            "selectedUnitDefId": "",
+            "selectedPilotDefId": ""
+          }
+        ]
+      }
+    ]
+  },
+  "targetsAllyTeam": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "31151ed6-cfc2-467e-98c4-9ae5bea784cf",
+    "teamName": "Target's Ally",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "neutralToAllTeam": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "61612bb3-abf9-4586-952a-0559fa9dcd75",
+    "teamName": "Neutral to All",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "hostileToAllTeam": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "3c9f3a20-ab03-4bcb-8ab6-b1ef0442bbf0",
+    "teamName": "Hostile to All",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "employersAllyTeam": {
+    "encounterLayerData": null,
+    "teamGuid": "70af7e7f-39a8-4e81-87c2-bd01dcb01b5e",
+    "teamName": "Employers Ally",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "contractTypeID": "SoloDuel"
+}

--- a/Flashpoint DLC Flashpoints/contracts/heroduel/SoloDuel_DrunkenRamblings.json
+++ b/Flashpoint DLC Flashpoints/contracts/heroduel/SoloDuel_DrunkenRamblings.json
@@ -1,0 +1,393 @@
+{
+  "ID" : "SoloDuel_DrunkenRamblings",
+  "contractName" : "Drunken Ramblings",
+  "contractDisplayStyle" : "BaseCampaignNormal",
+  "difficulty" : 5,
+  "difficultyUIModifier" : 0,
+  "weight" : 1,
+  "scope" : "STANDARD",
+  "finalDifficulty" : 0,
+  "representativeCastDefIDOverride" : null,
+  "missionSuccessStatementOverride" : null,
+  "badFaithStatementOverride" : null,
+  "goodFaithStatementOverride" : null,
+  "shortDescription" : "Last time I was ashore for R&R, a drunken MechWarrior came up to me, said he knew I was XO of a merc unit, and challenged my best to a duel, then passed out drunk. I asked around and apparently he's legit one of the best pilots on {TGT_SYSTEM.name}, who knew? Anyway, the local powers that be are putting up some good stakes and I think I found an employer to back us. What do you say, Commander? Want to go put the beatdown on a ranting drunk?",
+  "longDescription" : "Seriously, this guy has to be seen to be believed.",
+  "salvagePotential" : 3,
+  "requirementList" : [
+      {
+        "Scope" : "StarSystem",
+        "RequirementTags" : {
+            "items" : [],
+            "tagSetSourceFile" : ""
+        },
+        "ExclusionTags" : {
+            "items" : [],
+            "tagSetSourceFile" : ""
+        },
+        "RequirementComparisons" : []
+      }
+  ],
+  "OnContractSuccessResults" : [],
+  "OnContractFailureResults" : [],
+  "encounterPlayStyle" : "SinglePlayer",
+  "maxNumberOfPlayerUnits" : 1,
+  "lanceMinTonnage" : -1,
+  "lanceMaxTonnage" : -1,
+  "mechMinTonnages" : [
+      -1,
+      -1,
+      -1,
+      -1
+  ],
+  "mechMaxTonnages" : [
+      -1,
+      -1,
+      -1,
+      -1
+  ],
+  "mapMood" : null,
+  "startingFogOfWarVisibility" : "Surveyed",
+  "contractObjectiveList" : [
+      {
+          "contractObjective" : {
+              "EncounterObjectGuid" : "73275787-720a-4c33-9f20-953b1bbf48bd"
+          },
+          "title" : "Defeat the drunkard",
+          "description" : "",
+          "isPrimary" : true,
+          "forPlayer" : "Player1",
+          "objectiveGuids" : [
+              "a0b9c5b2-c594-4c5a-be1d-028a51c51519"
+          ]
+      }
+  ],
+  "objectiveList" : [
+      {
+          "objective" : {
+              "EncounterObjectGuid" : "a0b9c5b2-c594-4c5a-be1d-028a51c51519"
+          },
+          "title" : "Defeat the drunkard",
+          "description" : "",
+          "isPrimary" : true,
+          "OnSuccessResults" : [],
+          "OnFailureResults" : [],
+          "OnSuccessDialogueGUID" : null,
+          "OnFailureDialogueGUID" : null
+      }
+  ],
+  "artilleryObjectiveList" : [],
+  "buildingList" : [],
+  "chunkList" : [
+    {
+        "name" : "Chunk_SwapSpawnerPlacement",
+        "encounterChunk" : {
+            "EncounterObjectGuid" : "ed007c52-f4cb-4bfc-842a-a50454d8a82a"
+        },
+        "enableChunkFromContract" : false
+    }
+  ],
+  "cameraFocusHelperList" : [
+      {
+          "name" : "Spawner_PlayerLance",
+          "encounterObject" : {
+              "EncounterObjectGuid" : "76b654a6-4f2c-4a6f-86e6-d4cf868335fe"
+          }
+      },
+      {
+          "name" : "Lance_Enemy_Combatant",
+          "encounterObject" : {
+              "EncounterObjectGuid" : "f426f0dc-969d-477d-81a9-d02f9e1eff79"
+          }
+      }
+  ],
+  "dialogueList" : [
+      {
+          "dialogue" : {
+              "EncounterObjectGuid" : "73df8d9c-a274-48fd-98c9-2bd0d7860e83"
+          },
+          "name" : "Dialogue_MissionStart",
+          "overrideDialogueBucketId" : "",
+          "dialogueContent" : [
+              {
+                  "words" : "At least it's just one drunk, instead of a lance of them. Good luck, Commander.",
+                  "wordsColor" : {
+                      "r" : 1,
+                      "g" : 1,
+                      "b" : 1,
+                      "a" : 1
+                  },
+                  "selectedCastDefId" : "castDef_DariusDefault",
+                  "emote" : "Default",
+                  "audioName" : "NONE",
+                  "cameraFocusGuid" : "",
+                  "cameraDistance" : "Far",
+                  "cameraHeight" : "Default",
+                  "revealRadius" : -1
+              }
+          ]
+      },
+      {
+          "dialogue" : {
+              "EncounterObjectGuid" : "4011a4c3-cba2-4d22-b2b3-3b19a3297ab9"
+          },
+          "name" : "Dialogue_MissionSuccess",
+          "overrideDialogueBucketId" : "",
+          "dialogueContent" : [
+              {
+                  "words" : "As I've heard the pilots say in the barracks, talk shit, get hit. Well done putting that guy in his place, Commander.",
+                  "wordsColor" : {
+                      "r" : 1,
+                      "g" : 1,
+                      "b" : 1,
+                      "a" : 1
+                  },
+                  "selectedCastDefId" : "castDef_DariusDefault",
+                  "emote" : "Default",
+                  "audioName" : "NONE",
+                  "cameraFocusGuid" : "",
+                  "cameraDistance" : "Far",
+                  "cameraHeight" : "Default",
+                  "revealRadius" : -1
+              }
+          ]
+      },
+      {
+          "dialogue" : {
+              "EncounterObjectGuid" : "d3d33d95-9ed7-4686-b9eb-954ebe51cc02"
+          },
+          "name" : "Dialogue_MissionFailure",
+          "overrideDialogueBucketId" : "",
+          "dialogueContent" : [
+              {
+                  "words" : "Well. That's embarrassing. You'll probably hear about this one at poker night, Commander.",
+                  "wordsColor" : {
+                      "r" : 1,
+                      "g" : 1,
+                      "b" : 1,
+                      "a" : 1
+                  },
+                  "selectedCastDefId" : "castDef_DariusDefault",
+                  "emote" : "Default",
+                  "audioName" : "NONE",
+                  "cameraFocusGuid" : "",
+                  "cameraDistance" : "Far",
+                  "cameraHeight" : "Default",
+                  "revealRadius" : -1
+              }
+          ]
+      }
+  ],
+  "extractionOverrideList" : [],
+  "overwriteMissionCompleteWhenAutoComplete" : true,
+  "overrideAutoCompleteDialogueId" : null,
+  "disableNegotations" : false,
+  "disableLanceConfiguration" : false,
+  "disableCancelButton" : false,
+  "disableAfterAction" : false,
+  "contractRewardOverride" : -1,
+  "travelOnly" : false,
+  "useTravelCostPenalty" : false,
+  "usesExpiration" : false,
+  "expirationTimeOverride" : -1,
+  "negotiatedSalary" : 1,
+  "negotiatedSalvage" : 0,
+  "excludedFromProceduralGeneration" : false,
+  "player1Team" : {
+      "encounterLayerData" : {
+          "EncounterObjectGuid" : "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+      },
+      "teamGuid" : "bf40fd39-ccf9-47c4-94a6-061809681140",
+      "teamName" : "Player 1",
+      "faction" : "Player1sMercUnit",
+      "teamLeaderCastDefId" : "castDef_TeamLeader_Current",
+      "lanceOverrideList" : [
+          {
+              "lanceSpawner" : {
+                  "EncounterObjectGuid" : "76b654a6-4f2c-4a6f-86e6-d4cf868335fe"
+              },
+              "name" : "Spawner_PlayerLance",
+              "lanceDefId" : "Manual",
+              "lanceTagSet" : {
+                  "items" : [],
+                  "tagSetSourceFile" : "tags/LanceTags"
+              },
+              "lanceExcludedTagSet" : {
+                  "items" : [],
+                  "tagSetSourceFile" : "tags/LanceTags"
+              },
+              "spawnEffectTags" : {
+                  "items" : [],
+                  "tagSetSourceFile" : "tags/SpawnEffectTags"
+              },
+              "lanceDifficultyAdjustment" : 0,
+              "selectedLanceDefId" : null,
+              "selectedLanceDifficulty" : 0,
+              "unitSpawnPointOverrideList" : [
+                  {
+                      "unitSpawnPoint" : {
+                          "EncounterObjectGuid" : "ec9d2280-ca9a-4d90-8a20-963d8a4c0a39"
+                      },
+                      "customUnitName" : null,
+                      "customHeraldryDefId" : null,
+                      "unitType" : "Mech",
+                      "unitDefId" : "mechDef_None",
+                      "unitTagSet" : {
+                          "items" : [],
+                          "tagSetSourceFile" : "tags/UnitTags"
+                      },
+                      "unitExcludedTagSet" : {
+                          "items" : [],
+                          "tagSetSourceFile" : "tags/UnitTags"
+                      },
+                      "spawnEffectTags" : {
+                          "items" : [],
+                          "tagSetSourceFile" : "tags/SpawnEffectTags"
+                      },
+                      "pilotDefId" : "pilotDef_InheritLance",
+                      "pilotTagSet" : {
+                          "items" : [],
+                          "tagSetSourceFile" : "tags/PilotTags"
+                      },
+                      "pilotExcludedTagSet" : {
+                          "items" : [],
+                          "tagSetSourceFile" : "tags/PilotTags"
+                      },
+                      "selectedUnitType" : "UNDEFINED",
+                      "selectedUnitDefId" : null,
+                      "selectedPilotDefId" : null
+                  }
+              ]
+          }
+      ]
+  },
+  "player2Team" : {
+      "encounterLayerData" : {
+          "EncounterObjectGuid" : "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+      },
+      "teamGuid" : "757173dd-b4e1-4bb5-9bee-d78e623cc867",
+      "teamName" : "Player 2",
+      "faction" : "Player2sMercUnit",
+      "teamLeaderCastDefId" : "castDef_TeamLeader_Current",
+      "lanceOverrideList" : []
+  },
+  "employerTeam" : {
+      "encounterLayerData" : {
+          "EncounterObjectGuid" : "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+      },
+      "teamGuid" : "ecc8d4f2-74b4-465d-adf6-84445e5dfc230",
+      "teamName" : "Employer",
+      "faction" : "INVALID_UNSET",
+      "teamLeaderCastDefId" : "castDef_TeamLeader_Current",
+      "lanceOverrideList" : []
+  },
+  "targetTeam" : {
+      "encounterLayerData" : {
+          "EncounterObjectGuid" : "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+      },
+      "teamGuid" : "be77cadd-e245-4240-a93e-b99cc98902a5",
+      "teamName" : "Target",
+      "faction" : "INVALID_UNSET",
+      "teamLeaderCastDefId" : "castDef_TeamLeader_Current",
+      "lanceOverrideList" : [
+        {
+          "lanceSpawner" : {
+              "EncounterObjectGuid" : "f426f0dc-969d-477d-81a9-d02f9e1eff79"
+          },
+          "name" : "Lance_Enemy_Champion",
+          "lanceDefId" : "Tagged",
+          "lanceTagSet" : {
+              "items" : [
+                "lance_type_solo"
+              ],
+              "tagSetSourceFile" : "tags/LanceTags"
+          },
+          "lanceExcludedTagSet" : {
+              "items" : [],
+              "tagSetSourceFile" : "tags/LanceTags"
+          },
+          "spawnEffectTags" : {
+              "items" : [],
+              "tagSetSourceFile" : "tags/SpawnEffectTags"
+          },
+          "lanceDifficultyAdjustment" : 2,
+          "selectedLanceDefId" : "",
+          "selectedLanceDifficulty" : 0,
+          "unitSpawnPointOverrideList" : [
+              {
+                  "unitSpawnPoint" : {
+                      "EncounterObjectGuid" : "6cd3107e-0f9d-4809-ab8c-fb30faf4cd80"
+                  },
+                  "customUnitName" : "Duelist",
+                  "customHeraldryDefId" : "",
+                  "unitType" : "Mech",
+                  "unitDefId" : "mechDef_InheritLance",
+                  "unitTagSet" : {
+                      "items" : [],
+                      "tagSetSourceFile" : "tags/UnitTags"
+                  },
+                  "unitExcludedTagSet" : {
+                      "items" : [],
+                      "tagSetSourceFile" : "tags/UnitTags"
+                  },
+                  "spawnEffectTags" : {
+                      "items" : [],
+                      "tagSetSourceFile" : "tags/SpawnEffectTags"
+                  },
+                  "pilotDefId" : "pilotDef_InheritLance",
+                  "pilotTagSet" : {
+                      "items" : [],
+                      "tagSetSourceFile" : "tags/PilotTags"
+                  },
+                  "pilotExcludedTagSet" : {
+                      "items" : [],
+                      "tagSetSourceFile" : "tags/PilotTags"
+                  },
+                  "selectedUnitType" : "UNDEFINED",
+                  "selectedUnitDefId" : "",
+                  "selectedPilotDefId" : ""
+              }
+          ]
+      }
+      ]
+  },
+  "targetsAllyTeam" : {
+      "encounterLayerData" : {
+          "EncounterObjectGuid" : "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+      },
+      "teamGuid" : "31151ed6-cfc2-467e-98c4-9ae5bea784cf",
+      "teamName" : "Target's Ally",
+      "faction" : "INVALID_UNSET",
+      "teamLeaderCastDefId" : "castDef_TeamLeader_Current",
+      "lanceOverrideList" : []
+  },
+  "neutralToAllTeam" : {
+      "encounterLayerData" : {
+          "EncounterObjectGuid" : "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+      },
+      "teamGuid" : "61612bb3-abf9-4586-952a-0559fa9dcd75",
+      "teamName" : "Neutral to All",
+      "faction" : "INVALID_UNSET",
+      "teamLeaderCastDefId" : "castDef_TeamLeader_Current",
+      "lanceOverrideList" : []
+  },
+  "hostileToAllTeam" : {
+      "encounterLayerData" : {
+          "EncounterObjectGuid" : "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+      },
+      "teamGuid" : "3c9f3a20-ab03-4bcb-8ab6-b1ef0442bbf0",
+      "teamName" : "Hostile to All",
+      "faction" : "INVALID_UNSET",
+      "teamLeaderCastDefId" : "castDef_TeamLeader_Current",
+      "lanceOverrideList" : []
+  },
+  "employersAllyTeam" : {
+      "encounterLayerData" : null,
+      "teamGuid" : "70af7e7f-39a8-4e81-87c2-bd01dcb01b5e",
+      "teamName" : "Employers Ally",
+      "faction" : "INVALID_UNSET",
+      "teamLeaderCastDefId" : "castDef_TeamLeader_Current",
+      "lanceOverrideList" : []
+  },
+  "contractTypeID" : "SoloDuel"
+}

--- a/Flashpoint DLC Flashpoints/contracts/heroduel/SoloDuel_LifeLesson.json
+++ b/Flashpoint DLC Flashpoints/contracts/heroduel/SoloDuel_LifeLesson.json
@@ -1,0 +1,427 @@
+{
+  "ID": "SoloDuel_LifeLesson",
+  "contractName": "Life Lesson",
+  "contractDisplayStyle": "BaseCampaignNormal",
+  "difficulty": 2,
+  "difficultyUIModifier": 0,
+  "weight": 1,
+  "scope": "STANDARD",
+  "finalDifficulty": 0,
+  "representativeCastDefIDOverride": null,
+  "missionSuccessStatementOverride": null,
+  "badFaithStatementOverride": null,
+  "goodFaithStatementOverride": null,
+  "shortDescription": "A rich {TEAM_EMP.FactionDef.Demonym} business man has requested that we show his arrogant step-son what real fighting feels like. We thought {COMPANY.CompanyName} could help us here. Don't hold back. This father wants to teach a real life lesson - especially for his {TEAM_TAR.FactionDef.Demonym} side of the family.",
+  "longDescription": "I have to hand it to this guy. At least he cares enough about his son to teach him a thing or two. Even if that means a knock on the head... or two.",
+  "salvagePotential": 2,
+  "requirementList": [
+    {
+      "Scope": "StarSystem",
+      "RequirementTags": {
+        "items": [],
+        "tagSetSourceFile": ""
+      },
+      "ExclusionTags": {
+        "items": [],
+        "tagSetSourceFile": ""
+      },
+      "RequirementComparisons": [
+        {
+          "obj": "Employer.IsOwner",
+          "op": "Equal",
+          "val": 1,
+          "valueConstant": null
+        }
+      ]
+    }
+  ],
+  "OnContractSuccessResults": [],
+  "OnContractFailureResults": [],
+  "encounterPlayStyle": "SinglePlayer",
+  "maxNumberOfPlayerUnits": 1,
+  "lanceMinTonnage": -1,
+  "lanceMaxTonnage": -1,
+  "mechMinTonnages": [-1, -1, -1, -1],
+  "mechMaxTonnages": [35, -1, -1, -1],
+  "mapMood": null,
+  "startingFogOfWarVisibility": "Surveyed",
+  "contractObjectiveList": [
+    {
+      "contractObjective": {
+        "EncounterObjectGuid": "73275787-720a-4c33-9f20-953b1bbf48bd"
+      },
+      "title": "Teach a life lesson",
+      "description": "",
+      "isPrimary": true,
+      "forPlayer": "Player1",
+      "objectiveGuids": ["a0b9c5b2-c594-4c5a-be1d-028a51c51519"]
+    }
+  ],
+  "objectiveList": [
+    {
+      "objective": {
+        "EncounterObjectGuid": "a0b9c5b2-c594-4c5a-be1d-028a51c51519"
+      },
+      "title": "Destroy Arrogant Step-Son's Mech",
+      "description": "",
+      "isPrimary": true,
+      "OnSuccessResults": [],
+      "OnFailureResults": [],
+      "OnSuccessDialogueGUID": null,
+      "OnFailureDialogueGUID": null
+    }
+  ],
+  "artilleryObjectiveList": [],
+  "buildingList": [],
+  "chunkList": [
+    {
+      "name": "Chunk_SwapSpawnerPlacement",
+      "encounterChunk": {
+        "EncounterObjectGuid": "ed007c52-f4cb-4bfc-842a-a50454d8a82a"
+      },
+      "enableChunkFromContract": false
+    }
+  ],
+  "cameraFocusHelperList": [
+    {
+      "name": "Spawner_PlayerLance",
+      "encounterObject": {
+        "EncounterObjectGuid": "76b654a6-4f2c-4a6f-86e6-d4cf868335fe"
+      }
+    },
+    {
+      "name": "Lance_Enemy_Combatant",
+      "encounterObject": {
+        "EncounterObjectGuid": "f426f0dc-969d-477d-81a9-d02f9e1eff79"
+      }
+    }
+  ],
+  "dialogueList": [
+    {
+      "dialogue": {
+        "EncounterObjectGuid": "73df8d9c-a274-48fd-98c9-2bd0d7860e83"
+      },
+      "name": "Dialogue_MissionStart",
+      "overrideDialogueBucketId": "",
+      "dialogueContent": [
+        {
+          "words": "There he is, Commander.",
+          "wordsColor": {
+            "r": 1,
+            "g": 1,
+            "b": 1,
+            "a": 1
+          },
+          "selectedCastDefId": "castDef_DariusDefault",
+          "emote": "Default",
+          "audioName": "NONE",
+          "cameraFocusGuid": "",
+          "cameraDistance": "Far",
+          "cameraHeight": "Default",
+          "revealRadius": -1
+        },
+        {
+          "words": "This might be a real easy job but it's a job all the same. Knock him about a bit then finish things up. His Dad will be happier than he'll be.",
+          "wordsColor": {
+            "r": 1,
+            "g": 1,
+            "b": 1,
+            "a": 1
+          },
+          "selectedCastDefId": "castDef_DariusDefault",
+          "emote": "Default",
+          "audioName": "NONE",
+          "cameraFocusGuid": "",
+          "cameraDistance": "Far",
+          "cameraHeight": "Default",
+          "revealRadius": -1
+        }
+      ]
+    },
+    {
+      "dialogue": {
+        "EncounterObjectGuid": "4011a4c3-cba2-4d22-b2b3-3b19a3297ab9"
+      },
+      "name": "Dialogue_MissionSuccess",
+      "overrideDialogueBucketId": "",
+      "dialogueContent": [
+        {
+          "words": "He should get over his shock in a week or so, Commander. He might be sore for a bit longer.",
+          "wordsColor": {
+            "r": 1,
+            "g": 1,
+            "b": 1,
+            "a": 1
+          },
+          "selectedCastDefId": "castDef_DariusDefault",
+          "emote": "Default",
+          "audioName": "NONE",
+          "cameraFocusGuid": "",
+          "cameraDistance": "Far",
+          "cameraHeight": "Default",
+          "revealRadius": -1
+        }
+      ]
+    },
+    {
+      "dialogue": {
+        "EncounterObjectGuid": "d3d33d95-9ed7-4686-b9eb-954ebe51cc02"
+      },
+      "name": "Dialogue_MissionFailure",
+      "overrideDialogueBucketId": "",
+      "dialogueContent": [
+        {
+          "words": "That was unexpected, Commander. I don't think his Dad will pay up since we've just subjected him to a few years of bragging.",
+          "wordsColor": {
+            "r": 1,
+            "g": 1,
+            "b": 1,
+            "a": 1
+          },
+          "selectedCastDefId": "castDef_DariusDefault",
+          "emote": "Default",
+          "audioName": "NONE",
+          "cameraFocusGuid": "",
+          "cameraDistance": "Far",
+          "cameraHeight": "Default",
+          "revealRadius": -1
+        }
+      ]
+    },
+    {
+      "dialogue": {
+        "EncounterObjectGuid": "8971ddc6-a882-4066-923f-f8be03450ce2"
+      },
+      "name": "Dialogue_DuelTaunt",
+      "overrideDialogueBucketId": "",
+      "dialogueContent": [
+        {
+          "words": "So you're the rubbish my father is sending to train against? Just like the other servants... pitiful.",
+          "wordsColor": {
+            "r": 1,
+            "g": 1,
+            "b": 1,
+            "a": 1
+          },
+          "selectedCastDefId": "castDef_MC_ArrogantSon",
+          "emote": "Default",
+          "audioName": "NONE",
+          "cameraFocusGuid": "f426f0dc-969d-477d-81a9-d02f9e1eff79",
+          "cameraDistance": "Close",
+          "cameraHeight": "Default",
+          "revealRadius": -1
+        }
+      ]
+    }
+  ],
+  "extractionOverrideList": [],
+  "overwriteMissionCompleteWhenAutoComplete": true,
+  "overrideAutoCompleteDialogueId": null,
+  "disableNegotations": false,
+  "disableLanceConfiguration": false,
+  "disableCancelButton": false,
+  "disableAfterAction": false,
+  "contractRewardOverride": -1,
+  "travelOnly": false,
+  "useTravelCostPenalty": false,
+  "usesExpiration": false,
+  "expirationTimeOverride": -1,
+  "negotiatedSalary": 1,
+  "negotiatedSalvage": 0,
+  "excludedFromProceduralGeneration": false,
+  "player1Team": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "bf40fd39-ccf9-47c4-94a6-061809681140",
+    "teamName": "Player 1",
+    "faction": "Player1sMercUnit",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": [
+      {
+        "lanceSpawner": {
+          "EncounterObjectGuid": "76b654a6-4f2c-4a6f-86e6-d4cf868335fe"
+        },
+        "name": "Spawner_PlayerLance",
+        "lanceDefId": "Manual",
+        "lanceTagSet": {
+          "items": [],
+          "tagSetSourceFile": "tags/LanceTags"
+        },
+        "lanceExcludedTagSet": {
+          "items": [],
+          "tagSetSourceFile": "tags/LanceTags"
+        },
+        "spawnEffectTags": {
+          "items": [],
+          "tagSetSourceFile": "tags/SpawnEffectTags"
+        },
+        "lanceDifficultyAdjustment": 0,
+        "selectedLanceDefId": null,
+        "selectedLanceDifficulty": 0,
+        "unitSpawnPointOverrideList": [
+          {
+            "unitSpawnPoint": {
+              "EncounterObjectGuid": "ec9d2280-ca9a-4d90-8a20-963d8a4c0a39"
+            },
+            "customUnitName": null,
+            "customHeraldryDefId": null,
+            "unitType": "Mech",
+            "unitDefId": "mechDef_None",
+            "unitTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/UnitTags"
+            },
+            "unitExcludedTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/UnitTags"
+            },
+            "spawnEffectTags": {
+              "items": [],
+              "tagSetSourceFile": "tags/SpawnEffectTags"
+            },
+            "pilotDefId": "pilotDef_InheritLance",
+            "pilotTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/PilotTags"
+            },
+            "pilotExcludedTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/PilotTags"
+            },
+            "selectedUnitType": "UNDEFINED",
+            "selectedUnitDefId": null,
+            "selectedPilotDefId": null
+          }
+        ]
+      }
+    ]
+  },
+  "player2Team": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "757173dd-b4e1-4bb5-9bee-d78e623cc867",
+    "teamName": "Player 2",
+    "faction": "Player2sMercUnit",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "employerTeam": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "ecc8d4f2-74b4-465d-adf6-84445e5dfc230",
+    "teamName": "Employer",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "targetTeam": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "be77cadd-e245-4240-a93e-b99cc98902a5",
+    "teamName": "Target",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": [
+      {
+        "lanceSpawner": {
+          "EncounterObjectGuid": "f426f0dc-969d-477d-81a9-d02f9e1eff79"
+        },
+        "name": "Lance_Enemy_Champion",
+        "lanceDefId": "Tagged",
+        "lanceTagSet": {
+          "items": ["lance_type_light", "lance_type_mech"],
+          "tagSetSourceFile": "tags/LanceTags"
+        },
+        "lanceExcludedTagSet": {
+          "items": [],
+          "tagSetSourceFile": "tags/LanceTags"
+        },
+        "spawnEffectTags": {
+          "items": [],
+          "tagSetSourceFile": "tags/SpawnEffectTags"
+        },
+        "lanceDifficultyAdjustment": 2,
+        "selectedLanceDefId": "",
+        "selectedLanceDifficulty": 0,
+        "unitSpawnPointOverrideList": [
+          {
+            "unitSpawnPoint": {
+              "EncounterObjectGuid": "6cd3107e-0f9d-4809-ab8c-fb30faf4cd80"
+            },
+            "customUnitName": "Arrogant Step-Son",
+            "customHeraldryDefId": "",
+            "unitType": "Mech",
+            "unitDefId": "mechDef_InheritLance",
+            "unitTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/UnitTags"
+            },
+            "unitExcludedTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/UnitTags"
+            },
+            "spawnEffectTags": {
+              "items": [],
+              "tagSetSourceFile": "tags/SpawnEffectTags"
+            },
+            "pilotDefId": "pilotDef_InheritLance",
+            "pilotTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/PilotTags"
+            },
+            "pilotExcludedTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/PilotTags"
+            },
+            "selectedUnitType": "UNDEFINED",
+            "selectedUnitDefId": "",
+            "selectedPilotDefId": ""
+          }
+        ]
+      }
+    ]
+  },
+  "targetsAllyTeam": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "31151ed6-cfc2-467e-98c4-9ae5bea784cf",
+    "teamName": "Target's Ally",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "neutralToAllTeam": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "61612bb3-abf9-4586-952a-0559fa9dcd75",
+    "teamName": "Neutral to All",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "hostileToAllTeam": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "3c9f3a20-ab03-4bcb-8ab6-b1ef0442bbf0",
+    "teamName": "Hostile to All",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "employersAllyTeam": {
+    "encounterLayerData": null,
+    "teamGuid": "70af7e7f-39a8-4e81-87c2-bd01dcb01b5e",
+    "teamName": "Employers Ally",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "contractTypeID": "SoloDuel"
+}

--- a/Flashpoint DLC Flashpoints/contracts/heroduel/SoloDuel_ProxyWar.json
+++ b/Flashpoint DLC Flashpoints/contracts/heroduel/SoloDuel_ProxyWar.json
@@ -1,0 +1,411 @@
+{
+  "ID": "SoloDuel_ProxyWar",
+  "contractName": "Proxy War",
+  "contractDisplayStyle": "BaseCampaignNormal",
+  "difficulty": 5,
+  "difficultyUIModifier": 0,
+  "weight": 1,
+  "scope": "STANDARD",
+  "finalDifficulty": 0,
+  "representativeCastDefIDOverride": null,
+  "missionSuccessStatementOverride": null,
+  "badFaithStatementOverride": null,
+  "goodFaithStatementOverride": null,
+  "shortDescription": "The Governor of {TGT_SYSTEM.name} has been challenged to a proxy war duel by a rival {TEAM_TAR.FactionDef.Demonym} Governor. We'd like you to be his proxy in this fight. If you lose, we'll just deny it was ever agreed to. We don't want to actually risk anything here.",
+  "longDescription": "'Don't want to risk anything here?' I think they forget that we're putting our necks on the line. I suppose if the pay is good that's what we do.",
+  "salvagePotential": 3,
+  "requirementList": [
+    {
+      "Scope": "StarSystem",
+      "RequirementTags": {
+        "items": [],
+        "tagSetSourceFile": ""
+      },
+      "ExclusionTags": {
+        "items": [],
+        "tagSetSourceFile": ""
+      },
+      "RequirementComparisons": [
+        {
+          "obj": "Employer.IsOwner",
+          "op": "Equal",
+          "val": 1,
+          "valueConstant": null
+        }
+      ]
+    }
+  ],
+  "OnContractSuccessResults": [],
+  "OnContractFailureResults": [],
+  "encounterPlayStyle": "SinglePlayer",
+  "maxNumberOfPlayerUnits": 1,
+  "lanceMinTonnage": -1,
+  "lanceMaxTonnage": -1,
+  "mechMinTonnages": [-1, -1, -1, -1],
+  "mechMaxTonnages": [65, -1, -1, -1],
+  "mapMood": null,
+  "startingFogOfWarVisibility": "Surveyed",
+  "contractObjectiveList": [
+    {
+      "contractObjective": {
+        "EncounterObjectGuid": "73275787-720a-4c33-9f20-953b1bbf48bd"
+      },
+      "title": "Defeat the {TEAM_TAR.FactionDef.Demonym} duelist",
+      "description": "",
+      "isPrimary": true,
+      "forPlayer": "Player1",
+      "objectiveGuids": ["a0b9c5b2-c594-4c5a-be1d-028a51c51519"]
+    }
+  ],
+  "objectiveList": [
+    {
+      "objective": {
+        "EncounterObjectGuid": "a0b9c5b2-c594-4c5a-be1d-028a51c51519"
+      },
+      "title": "Defeat the {TEAM_TAR.FactionDef.Demonym} duelist",
+      "description": "",
+      "isPrimary": true,
+      "OnSuccessResults": [],
+      "OnFailureResults": [],
+      "OnSuccessDialogueGUID": null,
+      "OnFailureDialogueGUID": null
+    }
+  ],
+  "artilleryObjectiveList": [],
+  "buildingList": [],
+  "chunkList": [
+    {
+      "name": "Chunk_SwapSpawnerPlacement",
+      "encounterChunk": {
+        "EncounterObjectGuid": "ed007c52-f4cb-4bfc-842a-a50454d8a82a"
+      },
+      "enableChunkFromContract": false
+    }
+  ],
+  "cameraFocusHelperList": [
+    {
+      "name": "Spawner_PlayerLance",
+      "encounterObject": {
+        "EncounterObjectGuid": "76b654a6-4f2c-4a6f-86e6-d4cf868335fe"
+      }
+    },
+    {
+      "name": "Lance_Enemy_Combatant",
+      "encounterObject": {
+        "EncounterObjectGuid": "f426f0dc-969d-477d-81a9-d02f9e1eff79"
+      }
+    }
+  ],
+  "dialogueList": [
+    {
+      "dialogue": {
+        "EncounterObjectGuid": "73df8d9c-a274-48fd-98c9-2bd0d7860e83"
+      },
+      "name": "Dialogue_MissionStart",
+      "overrideDialogueBucketId": "",
+      "dialogueContent": [
+        {
+          "words": "At least we're keeping casualties down to a minimum here. Good luck, Commander.",
+          "wordsColor": {
+            "r": 1,
+            "g": 1,
+            "b": 1,
+            "a": 1
+          },
+          "selectedCastDefId": "castDef_DariusDefault",
+          "emote": "Default",
+          "audioName": "NONE",
+          "cameraFocusGuid": "",
+          "cameraDistance": "Far",
+          "cameraHeight": "Default",
+          "revealRadius": -1
+        }
+      ]
+    },
+    {
+      "dialogue": {
+        "EncounterObjectGuid": "4011a4c3-cba2-4d22-b2b3-3b19a3297ab9"
+      },
+      "name": "Dialogue_MissionSuccess",
+      "overrideDialogueBucketId": "",
+      "dialogueContent": [
+        {
+          "words": "Job done and we've saved some stuck up Governor their job. Time to get some rest, Commander.",
+          "wordsColor": {
+            "r": 1,
+            "g": 1,
+            "b": 1,
+            "a": 1
+          },
+          "selectedCastDefId": "castDef_DariusDefault",
+          "emote": "Default",
+          "audioName": "NONE",
+          "cameraFocusGuid": "",
+          "cameraDistance": "Far",
+          "cameraHeight": "Default",
+          "revealRadius": -1
+        }
+      ]
+    },
+    {
+      "dialogue": {
+        "EncounterObjectGuid": "d3d33d95-9ed7-4686-b9eb-954ebe51cc02"
+      },
+      "name": "Dialogue_MissionFailure",
+      "overrideDialogueBucketId": "",
+      "dialogueContent": [
+        {
+          "words": "Well, they did say they weren't going to acknowledge a loss. See how that works out. Let's get you back to the dropship, Commander.",
+          "wordsColor": {
+            "r": 1,
+            "g": 1,
+            "b": 1,
+            "a": 1
+          },
+          "selectedCastDefId": "castDef_DariusDefault",
+          "emote": "Default",
+          "audioName": "NONE",
+          "cameraFocusGuid": "",
+          "cameraDistance": "Far",
+          "cameraHeight": "Default",
+          "revealRadius": -1
+        }
+      ]
+    },
+    {
+      "dialogue": {
+        "EncounterObjectGuid": "8971ddc6-a882-4066-923f-f8be03450ce2"
+      },
+      "name": "Dialogue_DuelTaunt",
+      "overrideDialogueBucketId": "",
+      "dialogueContent": [
+        {
+          "words": "In the name of {TEAM_TAR.FactionDef.ShortName} I hereby challenge you to this war for {TGT_SYSTEM.name}! To the victor the spoils!",
+          "wordsColor": {
+            "r": 1,
+            "g": 1,
+            "b": 1,
+            "a": 1
+          },
+          "selectedCastDefId": "castDef_Contract_TheProfessional",
+          "emote": "Default",
+          "audioName": "NONE",
+          "cameraFocusGuid": "f426f0dc-969d-477d-81a9-d02f9e1eff79",
+          "cameraDistance": "Close",
+          "cameraHeight": "Default",
+          "revealRadius": -1
+        }
+      ]
+    }
+  ],
+  "extractionOverrideList": [],
+  "overwriteMissionCompleteWhenAutoComplete": true,
+  "overrideAutoCompleteDialogueId": null,
+  "disableNegotations": false,
+  "disableLanceConfiguration": false,
+  "disableCancelButton": false,
+  "disableAfterAction": false,
+  "contractRewardOverride": -1,
+  "travelOnly": false,
+  "useTravelCostPenalty": false,
+  "usesExpiration": false,
+  "expirationTimeOverride": -1,
+  "negotiatedSalary": 1,
+  "negotiatedSalvage": 0,
+  "excludedFromProceduralGeneration": false,
+  "player1Team": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "bf40fd39-ccf9-47c4-94a6-061809681140",
+    "teamName": "Player 1",
+    "faction": "Player1sMercUnit",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": [
+      {
+        "lanceSpawner": {
+          "EncounterObjectGuid": "76b654a6-4f2c-4a6f-86e6-d4cf868335fe"
+        },
+        "name": "Spawner_PlayerLance",
+        "lanceDefId": "Manual",
+        "lanceTagSet": {
+          "items": [],
+          "tagSetSourceFile": "tags/LanceTags"
+        },
+        "lanceExcludedTagSet": {
+          "items": [],
+          "tagSetSourceFile": "tags/LanceTags"
+        },
+        "spawnEffectTags": {
+          "items": [],
+          "tagSetSourceFile": "tags/SpawnEffectTags"
+        },
+        "lanceDifficultyAdjustment": 0,
+        "selectedLanceDefId": null,
+        "selectedLanceDifficulty": 0,
+        "unitSpawnPointOverrideList": [
+          {
+            "unitSpawnPoint": {
+              "EncounterObjectGuid": "ec9d2280-ca9a-4d90-8a20-963d8a4c0a39"
+            },
+            "customUnitName": null,
+            "customHeraldryDefId": null,
+            "unitType": "Mech",
+            "unitDefId": "mechDef_None",
+            "unitTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/UnitTags"
+            },
+            "unitExcludedTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/UnitTags"
+            },
+            "spawnEffectTags": {
+              "items": [],
+              "tagSetSourceFile": "tags/SpawnEffectTags"
+            },
+            "pilotDefId": "pilotDef_InheritLance",
+            "pilotTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/PilotTags"
+            },
+            "pilotExcludedTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/PilotTags"
+            },
+            "selectedUnitType": "UNDEFINED",
+            "selectedUnitDefId": null,
+            "selectedPilotDefId": null
+          }
+        ]
+      }
+    ]
+  },
+  "player2Team": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "757173dd-b4e1-4bb5-9bee-d78e623cc867",
+    "teamName": "Player 2",
+    "faction": "Player2sMercUnit",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "employerTeam": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "ecc8d4f2-74b4-465d-adf6-84445e5dfc230",
+    "teamName": "Employer",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "targetTeam": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "be77cadd-e245-4240-a93e-b99cc98902a5",
+    "teamName": "Target",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": [
+      {
+        "lanceSpawner": {
+          "EncounterObjectGuid": "f426f0dc-969d-477d-81a9-d02f9e1eff79"
+        },
+        "name": "Lance_Enemy_Champion",
+        "lanceDefId": "Tagged",
+        "lanceTagSet": {
+          "items": ["lance_type_heavy", "lance_type_mech"],
+          "tagSetSourceFile": "tags/LanceTags"
+        },
+        "lanceExcludedTagSet": {
+          "items": [],
+          "tagSetSourceFile": "tags/LanceTags"
+        },
+        "spawnEffectTags": {
+          "items": [],
+          "tagSetSourceFile": "tags/SpawnEffectTags"
+        },
+        "lanceDifficultyAdjustment": 2,
+        "selectedLanceDefId": "",
+        "selectedLanceDifficulty": 0,
+        "unitSpawnPointOverrideList": [
+          {
+            "unitSpawnPoint": {
+              "EncounterObjectGuid": "6cd3107e-0f9d-4809-ab8c-fb30faf4cd80"
+            },
+            "customUnitName": "Duelist",
+            "customHeraldryDefId": "",
+            "unitType": "Mech",
+            "unitDefId": "mechDef_InheritLance",
+            "unitTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/UnitTags"
+            },
+            "unitExcludedTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/UnitTags"
+            },
+            "spawnEffectTags": {
+              "items": [],
+              "tagSetSourceFile": "tags/SpawnEffectTags"
+            },
+            "pilotDefId": "pilotDef_InheritLance",
+            "pilotTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/PilotTags"
+            },
+            "pilotExcludedTagSet": {
+              "items": [],
+              "tagSetSourceFile": "tags/PilotTags"
+            },
+            "selectedUnitType": "UNDEFINED",
+            "selectedUnitDefId": "",
+            "selectedPilotDefId": ""
+          }
+        ]
+      }
+    ]
+  },
+  "targetsAllyTeam": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "31151ed6-cfc2-467e-98c4-9ae5bea784cf",
+    "teamName": "Target's Ally",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "neutralToAllTeam": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "61612bb3-abf9-4586-952a-0559fa9dcd75",
+    "teamName": "Neutral to All",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "hostileToAllTeam": {
+    "encounterLayerData": {
+      "EncounterObjectGuid": "c1dd76b9-5f5f-46f1-b5a2-d1f22dd4991b"
+    },
+    "teamGuid": "3c9f3a20-ab03-4bcb-8ab6-b1ef0442bbf0",
+    "teamName": "Hostile to All",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "employersAllyTeam": {
+    "encounterLayerData": null,
+    "teamGuid": "70af7e7f-39a8-4e81-87c2-bd01dcb01b5e",
+    "teamName": "Employers Ally",
+    "faction": "INVALID_UNSET",
+    "teamLeaderCastDefId": "castDef_TeamLeader_Current",
+    "lanceOverrideList": []
+  },
+  "contractTypeID": "SoloDuel"
+}

--- a/Flashpoint DLC Flashpoints/events/event_FP_HeroDuel.json
+++ b/Flashpoint DLC Flashpoints/events/event_FP_HeroDuel.json
@@ -1,0 +1,159 @@
+{
+    "Description": {
+        "Id": "event_FP_HeroDuel",
+        "Name": "A Challenge",
+        "Details": "During the morning briefing, Darius mentions that an unusual contract has popped up on the radar - [[DM.BaseDescriptionDefs[LoreIronwood]Ironwood Productions]] would like to hire you for a duel. One of their clients, a famous [[DM.BaseDescriptionDefs[LoreSolaris7],Solaris]] gladiator, is looking to make a name for themselves by challenging prominent mercenary companies around the Inner Sphere, and Ironwood is promoting their tour.\r\n\n\nDarius goes on. \"Here's the juicy bit, {COMMANDER.Callsign}. While Ironwood will be pocketing all tho holovid profits, the prize we'll be fighting for is a mech.\"\r\n\n\nYang practically rips the contract out of Darius' hand, scanning it over quickly. \"Woah, Commander. We've got to take this. This prize? It's not just any old mech. It's a custom job. We won't find anything like this just wandering around the battlefield.\"",
+        "Icon": "uixTxrSpot_IncomingTransimission.png"
+    },
+    "Scope": "Company",
+    "Weight": 1000,
+    "Requirements": {
+        "Scope": "Company",
+        "RequirementTags": {},
+        "ExclusionTags": {
+            "tagSetSourceFile": "Tags/CompanyTags",
+            "items": [
+                "event_HeroDuel"
+            ]
+        },
+        "RequirementComparisons": []
+    },
+    "AdditionalRequirements": [],
+    "AdditionalObjects": [],
+    "Options": [
+        {
+            "Description": {
+                "Id": "outcome_0",
+                "Name": "No reason not to look into it.",
+                "Details": "Spawn the hero challenge flashpoint",
+                "Icon": null
+            },
+            "RequirementList": [],
+            "ResultSets": [
+                {
+                    "Description": {
+                        "Id": "outcome_0_0",
+                        "Name": "Challenge Accepted",
+                        "Details": "Darius nods. \"I'll get in touch with Ironwood and figure out the best place in the tour for a meetup.\" Yang is already busy searching the hypernet for more information about the rumored \"Hero mech\" you might soon get your hands on.",
+                        "Icon": null
+                    },
+                    "Weight": 100,
+                    "Results": [
+                        {
+                            "Scope": "Company",
+                            "Requirements": null,
+                            "AddedTags": {
+                                "tagSetSourceFile": "Tags/CompanyTags",
+                                "items": [
+                                    "event_HeroDuel"
+                                ]
+                            },
+                            "RemovedTags": {},
+                            "Stats": [],
+                            "Actions": [
+                                {
+                                    "Type": "System_AddFlashpoint",
+                                    "value": "fp_HeroDuel",
+                                    "valueConstant": null,
+                                    "additionalValues": [
+                                        "starsystemdef_Solaris"
+                                    ]
+                                }
+                            ],
+                            "ForceEvents": null,
+                            "TemporaryResult": false,
+                            "ResultDuration": 0
+                        }
+                    ]
+                },
+                {
+                    "Description": {
+                        "Id": "outcome_0_1",
+                        "Name": "Challenge Accepted",
+                        "Details": "Darius nods. \"I'll get in touch with Ironwood and figure out the best place in the tour for a meetup.\" Yang is already busy searching the hypernet for more information about the rumored \"Hero mech\" you might soon get your hands on.",
+                        "Icon": null
+                    },
+                    "Weight": 100,
+                    "Results": [
+                        {
+                            "Scope": "Company",
+                            "Requirements": null,
+                            "AddedTags": {
+                                "tagSetSourceFile": "",
+                                "items": [
+                                    "event_HeroDuel"
+                                ]
+                            },
+                            "RemovedTags": {},
+                            "Stats": [],
+                            "Actions": [
+                                {
+                                    "Type": "System_AddFlashpoint",
+                                    "value": "fp_HeroDuel",
+                                    "valueConstant": null,
+                                    "additionalValues": [
+                                        "starsystemdef_Hardcore"
+                                    ]
+                                }
+                            ],
+                            "ForceEvents": null,
+                            "TemporaryResult": false,
+                            "ResultDuration": 0
+                        }
+                    ]
+                },
+                {
+                    "Description": {
+                        "Id": "outcome_0_2",
+                        "Name": "Challenge Accepted",
+                        "Details": "Darius nods. \"I'll get in touch with Ironwood and figure out the best place in the tour for a meetup.\" Yang is already busy searching the hypernet for more information about the rumored \"Hero mech\" you might soon get your hands on.",
+                        "Icon": null
+                    },
+                    "Weight": 100,
+                    "Results": [
+                        {
+                            "Scope": "Company",
+                            "Requirements": null,
+                            "AddedTags": {
+                                "tagSetSourceFile": "",
+                                "items": [
+                                    "event_HeroDuel"
+                                ]
+                            },
+                            "RemovedTags": {},
+                            "Stats": [],
+                            "Actions": [
+                                {
+                                    "Type": "System_AddFlashpoint",
+                                    "value": "fp_HeroDuel",
+                                    "valueConstant": null,
+                                    "additionalValues": [
+                                        "starsystemdef_Galatea"
+                                    ]
+                                }
+                            ],
+                            "ForceEvents": null,
+                            "TemporaryResult": false,
+                            "ResultDuration": 0
+                        }
+                    ]
+                }
+            ],
+            "Requirements": {
+                "Scope": "Company",
+                "RequirementTags": {
+                    "tagSetSourceFile": "",
+                    "items": []
+                },
+                "ExclusionTags": {
+                    "tagSetSourceFile": "",
+                    "items": []
+                },
+                "RequirementComparisons": []
+            }
+        }
+    ],
+    "PublishState": "PUBLISHED",
+    "ValidationState": "UNTESTED",
+    "EventType": "NORMAL"
+}

--- a/Flashpoint DLC Flashpoints/flashpoints/fp_HeroDuel.json
+++ b/Flashpoint DLC Flashpoints/flashpoints/fp_HeroDuel.json
@@ -1,0 +1,46 @@
+{
+    "Description" : {
+        "Id" : "fp_HeroDuel",
+        "Name" : "",
+        "Details" : "Selects a hero mech to fight. Never spawns naturally, only event triggered.",
+        "Icon" : ""
+    },
+    "Weight" : 10,
+    "InternalName" : "HeroDues",
+    "PublishState" : "PUBLISHED",
+    "Difficulty" : 6,
+    "Requirements" : [],
+    "LocationRequirements" : {
+        "Scope" : "Company",
+        "RequirementTags" : {
+            "items" : [
+                "event_HeroDuel",
+            ],
+            "tagSetSourceFile" : "Tags/CompanyTags"
+        },,
+        "ExclusionTags" : {
+            "items" : [
+                "event_HeroDuel",
+            ],
+            "tagSetSourceFile" : "Tags/CompanyTags"
+        },
+        "RequirementComparisons" : []
+    },
+    "PotentialEmployers" : [
+        "SecuritySolutionsInc"
+    ],
+    "TargetFaction" : "SecuritySolutionsInc",
+    "AllowRefitTime" : true,
+    "FlashpointLength" : "SHORT",
+    "Repeatable" : false,
+    "MilestoneSetID" : "ms_fp_HeroDuel",
+    "UseAvailableTimeoutOverride" : true,
+    "AvailableTimeout" : 90,
+    "UseInProgressTimeoutOverride" : false,
+    "InProgressTimeout" : 0,
+    "RewardCollectionID" : "itemCollection_loot_none",
+    "UnitDropTonnageHint" : "None",
+    "LanceDropTonnageHint" : "Light",
+    "FlashpointShortDescription" : "Our gladiator awaits your arrival. Their fans are clamouring to see them match against someone of your reputation, and we're ready to broadcast the event all over the Solaris VII tournament circuit. Good luck, and make the fight one to remember.",
+    "FlashpointDescriberCastDefId" : "castDef_FP_gladiator_IronwoodRepDefault"
+}

--- a/Flashpoint DLC Flashpoints/milestoneSets/ms_fp_HeroDuel.json
+++ b/Flashpoint DLC Flashpoints/milestoneSets/ms_fp_HeroDuel.json
@@ -1,0 +1,294 @@
+{
+    "StartingMilestoneID": "ms_fp_HeroDuel_001_Start",
+    "Milestones": [
+        {
+            "Description": {
+                "Id": "ms_fp_HeroDuel_001_Start",
+                "Name": "Start",
+                "Details": "flashpoint",
+                "Icon": null
+            },
+            "Scope": "Company",
+            "Requirements": [],
+            "Results": [
+                {
+                    "Scope": "Company",
+                    "Requirements": null,
+                    "AddedTags": {},
+                    "RemovedTags": {},
+                    "Stats": [],
+                    "Actions": [
+                        {
+                            "Type": "Flashpoint_SetNextMilestone",
+                            "value": "ms_fp_HeroDuel_002_Mission",
+                            "valueConstant": null,
+                            "additionalValues": null
+                        }
+                    ],
+                    "ForceEvents": [],
+                    "TemporaryResult": false,
+                    "ResultDuration": 0
+                }
+            ],
+            "Repeatable": false,
+            "UseRandomInvocation": false,
+            "InvokeChance": 0
+        },
+        {
+            "Description": {
+                "Id": "ms_fp_HeroDuel_002_Mission",
+                "Name": "Mission",
+                "Details": "flashpoint",
+                "Icon": null
+            },
+            "Scope": "Company",
+            "Requirements": [],
+            "Results": [
+                {
+                    "Scope": "Company",
+                    "Requirements": null,
+                    "AddedTags": {},
+                    "RemovedTags": {},
+                    "Stats": null,
+                    "Actions": [
+                        {
+                            "Type": "Flashpoint_StartContract",
+                            "value": "SoloDuel",
+                            "valueConstant": null,
+                            "additionalValues": [
+                                "",
+                                "",
+                                null,
+                                "SecuritySolutionsInc",
+                                "SecuritySolutionsInc",
+                                "6",
+                                "ms_fp_HeroDuel_003_UpdateTags",
+                                null,
+                                null,
+                                null,
+                                null,
+                                null
+                            ]
+                        }
+                    ],
+                    "ForceEvents": null,
+                    "TemporaryResult": false,
+                    "ResultDuration": 0
+                }
+            ],
+            "Repeatable": false,
+            "UseRandomInvocation": false,
+            "InvokeChance": 0
+        },
+        {
+            "Description": {
+                "Id": "ms_fp_HeroDuel_003_UpdateTags",
+                "Name": "Complete",
+                "Details": "flashpoint",
+                "Icon": null
+            },
+            "Scope": "Company",
+            "Requirements": [],
+            "Results": [
+                {
+                    "Scope": "Company",
+                    "Requirements": {
+                        "Scope": "Company",
+                        "RequirementTags": {
+                            "tagSetSourceFile": "Tags/CompanyTags",
+                            "items": [
+                                "flashpoint_HeroDuel_Catapharact",
+                                "flashpoint_HeroDuel_Ciceda"
+                            ]
+                        },
+                        "ExclusionTags": {},
+                        "RequirementComparisons": []
+                    },
+                    "AddedTags": {
+                        "items": [
+                            "flashpoint_HeroDuel_complete"
+                        ],
+                        "tagSetSourceFile": "Tags/CompanyTags"
+                    },
+                    "RemovedTags": {
+                        "items": [
+                            "flashpoint_HeroDuel_Catapharact",
+                            "flashpoint_HeroDuel_Ciceda"
+                        ],
+                        "tagSetSourceFile": "Tags/CompanyTags"
+                    },
+                    "Stats": null,
+                    "Actions": [],
+                    "ForceEvents": [],
+                    "TemporaryResult": false,
+                    "ResultDuration": 0
+                },
+                {
+                    "Scope": "Company",
+                    "Requirements": null,
+                    "AddedTags": {},
+                    "RemovedTags": {},
+                    "Stats": null,
+                    "Actions": [
+                        {
+                            "Type": "Flashpoint_SetNextMilestone",
+                            "value": "ms_fp_HeroDuel_004_NextEvent",
+                            "valueConstant": null,
+                            "additionalValues": null
+                        }
+                    ],
+                    "ForceEvents": [],
+                    "TemporaryResult": false,
+                    "ResultDuration": 0
+                }
+
+            ],
+            "Repeatable": false,
+            "UseRandomInvocation": false,
+            "InvokeChance": 0
+        },
+        {
+            "Description": {
+                "Id": "ms_fp_HeroDuel_001_Start",
+                "Name": "Start",
+                "Details": "flashpoint",
+                "Icon": null
+            },
+            "Scope": "Company",
+            "Requirements": [],
+            "Results": [
+                {
+                    "Scope": "Company",
+                    "Requirements": {
+                        "Scope": "Company",
+                        "RequirementTags": {},
+                        "ExclusionTags": {
+                            "tagSetSourceFile": "Tags/CompanyTags",
+                            "items": [
+                                "flashpoint_HeroDuel_complete"
+                            ]
+                        },
+                        "RequirementComparisons": []
+                    },
+                    "AddedTags": {},
+                    "RemovedTags": {},
+                    "Stats": [],
+                    "Actions": [],
+                    "ForceEvents": [
+                        {
+                            "Scope" : "Company",
+                            "EventID" : "event_FP_HeroDuel",
+                            "MinDaysWait" : 60,
+                            "MaxDaysWait" : 90,
+                            "Probability" : 100
+                        }
+                    ],
+                    "TemporaryResult": false,
+                    "ResultDuration": 0
+                },
+                {
+                    "Scope": "Company",
+                    "Requirements": null,
+                    "AddedTags": {},
+                    "RemovedTags": {},
+                    "Stats": [],
+                    "Actions": [
+                        {
+                            "Type": "Flashpoint_CompleteFlashpoint",
+                            "value": "ms_fp_HeroDuel_005_Reward",
+                            "valueConstant": null,
+                            "additionalValues": null
+                        }
+                    ],
+                    "ForceEvents": [],
+                    "TemporaryResult": false,
+                    "ResultDuration": 0
+                }
+            ],
+            "Repeatable": false,
+            "UseRandomInvocation": false,
+            "InvokeChance": 0
+        },
+        {
+            "Description": {
+                "Id": "ms_fp_HeroDuel_005_Reward",
+                "Name": "Reward",
+                "Details": "Extra rewards, including Reputation and bonus C-Bills go here",
+                "Icon": null
+            },
+            "Scope": "Company",
+            "Requirements": [],
+            "Results": [
+                {
+                    "Scope": "Company",
+                    "Requirements": {
+                        "Scope": "Company",
+                        "RequirementTags": {
+                            "tagSetSourceFile": "Tags/CompanyTags",
+                            "items": [
+                                "flashpoint_HeroDuel_Catapharact_temp"
+                            ]
+                        },
+                        "ExclusionTags": {},
+                        "RequirementComparisons": []
+                    },
+                    "AddedTags": {},
+                    "RemovedTags": {
+                        "items": [
+                            "flashpoint_HeroDuel_Catapharact_temp"
+                        ],
+                        "tagSetSourceFile": "Tags/CompanyTags"
+                    },
+                    "Stats": [],
+                    "Actions": [
+                        {
+                            "Type" : "Mech_AddRoster",
+                            "value" : "mechdef_cataphract_CTF-IM",
+                            "valueConstant" : null,
+                            "additionalValues" : null
+                        }
+                    ],
+                    "ForceEvents": null,
+                    "TemporaryResult": false,
+                    "ResultDuration": 0
+                },
+                {
+                    "Scope": "Company",
+                    "Requirements": {
+                        "Scope": "Company",
+                        "RequirementTags": {
+                            "tagSetSourceFile": "Tags/CompanyTags",
+                            "items": [
+                                "flashpoint_HeroDuel_Ciceda"
+                            ]
+                        },
+                        "ExclusionTags": {},
+                        "RequirementComparisons": []
+                    },
+                    "AddedTags": {},
+                    "RemovedTags": {
+                        "items": [
+                            "flashpoint_HeroDuel_Ciceda_temp"
+                        ],
+                        "tagSetSourceFile": "Tags/CompanyTags"
+                    },
+                    "Stats": [],
+                    "Actions": [
+                        {
+                            "Type" : "Mech_AddRoster",
+                            "value" : "mechdef_cicada_CDA-X5",
+                            "valueConstant" : null,
+                            "additionalValues" : null
+                        }
+                    ],
+                    "ForceEvents": null,
+                    "TemporaryResult": false,
+                    "ResultDuration": 0
+                }
+            ],
+            "Repeatable": false,
+            "UseRandomInvocation": false,
+            "InvokeChance": 0
+        }
+    ]
+}

--- a/MissionControl/contractTypeBuilds/HeroDuel/common.jsonc
+++ b/MissionControl/contractTypeBuilds/HeroDuel/common.jsonc
@@ -1,0 +1,154 @@
+{
+  "Key": "HeroDuel", // Links to the ContractType Name
+  "Chunks": [
+    {
+      "Name": "Chunk_PlayerLance",
+      "Type": "Chunk",
+      "SubType": "PlayerLance",
+      "Children": [
+        {
+          "Name": "Spawner_PlayerLance",
+          "Type": "Spawner",
+          "SubType": "SimpleSpawner",
+          "Position": {
+            "Type": "World", // World, Local, SpawnProfile (Anywhere, AtBoundary, AtTarget, NearTarget)
+            "Value": { "x": -90, "y": 86, "z": 40 }
+          },
+          "Rotation": {
+            "Type": "World", // World, Local
+            "Value": { "x": 0, "y": 30, "z": 0 }
+          },
+          "Team": "Player1",
+          "Guid": "76b654a6-4f2c-4a6f-86e6-d4cf868335fe", // Must be this Guid and the contract .json must have this specific. It's hardcoded in BT for PlayerLance.
+          "SpawnPoints": 1,
+          "SpawnPointGuids": ["ec9d2280-ca9a-4d90-8a20-963d8a4c0a39"], // Must match the unit spawn guids in the contract .json
+          "SpawnType": "Instant" // Leopard, DropPod, Instant
+        }
+      ]
+    },
+    {
+      "Name": "Chunk_DestroyWholeLance",
+      "Type": "Chunk",
+      "SubType": "DestroyWholeLance",
+      "Position": {
+        "Type": "World", // World, Local, SpawnProfile (Anywhere, AtBoundary, AtTarget, NearTarget)
+        "Value": { "x": 0, "y": 0, "z": 0 }
+      },
+      "Children": [
+        {
+          "Name": "Lance_Enemy_OpposingForce",
+          "Type": "Spawner",
+          "SubType": "SimpleSpawner",
+          "Position": {
+            "Type": "World", // World, Local, SpawnProfile (Anywhere, AtBoundary, AtTarget, NearTarget)
+            "Value": { "x": 0, "y": 60, "z": 650 }
+          },
+          "Rotation": {
+            "Type": "World", // World, Local
+            "Value": { "x": 0, "y": 180, "z": 0 }
+          },
+          "Team": "Target",
+          "Guid": "f426f0dc-969d-477d-81a9-d02f9e1eff79", // Must match the spawner guids in the contract .json
+          "SpawnPoints": 1,
+          "SpawnPointGuids": ["6cd3107e-0f9d-4809-ab8c-fb30faf4cd80"], // Must match the unit spawn guids in the contract .json
+          "SpawnType": "Instant", // Leopard, DropPod, Instant
+          "AI": [
+            {
+              "Type": "MagicKnowledgeByTag",
+              "Action": "Add",
+              "Tags": ["Player 1"]
+            }
+          ]
+        },
+        {
+          "Name": "Objective_DestroyLance",
+          "Type": "Objective",
+          "SubType": "DestroyLance",
+          "Guid": "a0b9c5b2-c594-4c5a-be1d-028a51c51519", // Must match the objective guid in the contract .json
+          "ContractObjectiveGuid": "73275787-720a-4c33-9f20-953b1bbf48bd", // Must match the contract guid in the contract .json
+          "Title": "Destroy the enemy lance",
+          "Priority": 1,
+          "IsPrimaryObjective": true,
+          "LanceToDestroyGuid": "f426f0dc-969d-477d-81a9-d02f9e1eff79"
+        }
+      ]
+    },
+    {
+      "Name": "Chunk_EncounterBoundary",
+      "Type": "Chunk",
+      "SubType": "EncounterBoundary",
+      "Children": [
+        {
+          "Name": "EncounterBoundaryRect",
+          "Type": "Region",
+          "SubType": "Boundary",
+          "Position": {
+            "Type": "World", // World, Local, SpawnProfile (Anywhere, AtBoundary, AtTarget, NearTarget)
+            "Value": { "x": 15, "y": 50, "z": 450 }
+          },
+          "Width": 900,
+          "Length": 1024
+        }
+      ]
+    },
+    {
+      "Name": "Chunk_DefaultDialogue",
+      "Type": "Chunk",
+      "SubType": "Dialogue",
+      "Children": [
+        {
+          "Name": "Dialogue_MissionStart",
+          "Type": "Dialogue",
+          "SubType": "Simple",
+          "Guid": "73df8d9c-a274-48fd-98c9-2bd0d7860e83", // Must match the dialogue guid in the contract .json
+          "ShowOnlyOnce": true
+        },
+        {
+          "Name": "Dialogue_MissionSuccess",
+          "Type": "Dialogue",
+          "SubType": "Simple",
+          "Guid": "4011a4c3-cba2-4d22-b2b3-3b19a3297ab9", // Must match the dialogue guid in the contract .json
+          // "Trigger": "OnObjectiveSucceeded", // Anything from 'MessageCenterMessageType'
+          "ShowOnlyOnce": true
+        },
+        {
+          "Name": "Dialogue_MissionFailure",
+          "Type": "Dialogue",
+          "SubType": "Simple",
+          "Guid": "d3d33d95-9ed7-4686-b9eb-954ebe51cc02", // Must match the dialogue guid in the contract .json
+          "ShowOnlyOnce": true
+        }
+      ]
+    },
+    {
+      "Name": "Chunk_DuelTaunt",
+      "Type": "Chunk",
+      "SubType": "Dialogue",
+      "Children": [
+        {
+          "Name": "Dialogue_DuelTaunt",
+          "Type": "Dialogue",
+          "SubType": "Simple",
+          "Guid": "8971ddc6-a882-4066-923f-f8be03450ce2", // Must match the dialogue guid in the contract .json
+          "Trigger": "OnFirstContact"
+        }
+      ]
+    },
+    {
+      "Name": "Chunk_SwapSpawnerPlacement",
+      "Type": "Chunk",
+      "SubType": "Placement",
+      "ControlledByContract": true,
+      "Guid": "ed007c52-f4cb-4bfc-842a-a50454d8a82a",
+      "Children": [
+        {
+          "Name": "SwapPlacement_SwapLanceSpawners",
+          "Type": "SwapPlacement",
+          "SubType": "EncounterStructure",
+          "TargetGuid1": "76b654a6-4f2c-4a6f-86e6-d4cf868335fe", // Player spawner
+          "TargetGuid2": "f426f0dc-969d-477d-81a9-d02f9e1eff79" // Enemy spawner
+        }
+      ]
+    }
+  ]
+}

--- a/MissionControl/contractTypeBuilds/HeroDuel/deathvalley_desert_open_area.jsonc
+++ b/MissionControl/contractTypeBuilds/HeroDuel/deathvalley_desert_open_area.jsonc
@@ -1,0 +1,49 @@
+// This file overrides the contract type 'common.json' file with map specific values (such as locations and rotations)
+{
+  "EncounterLayerId": "mapArena_deathValley_aDes.73b9ebfe-b62b-4ffb-87b9-a0191d2530b3",
+  "Overrides": [
+    {
+      "Path": "Chunks[?(@.Name == 'Chunk_PlayerLance')].Children[?(@.Name == 'Spawner_PlayerLance')]",
+      "Action": "ObjectMerge",
+      "Value": {
+        "Name": "Spawner_PlayerLance",
+        "Position": {
+          "Type": "World",
+          "Value": { "x": -90, "y": 86, "z": 40 }
+        },
+        "Rotation": {
+          "Type": "World",
+          "Value": { "x": 0, "y": 0, "z": 0 }
+        }
+      }
+    },
+    {
+      "Path": "Chunks[?(@.Name == 'Chunk_DestroyWholeLance')].Children[?(@.Name == 'Lance_Enemy_OpposingForce')]",
+      "Action": "ObjectMerge",
+      "Value": {
+        "Name": "Lance_Enemy_OpposingForce",
+        "Position": {
+          "Type": "World",
+          "Value": { "x": -80, "y": 260, "z": 700 }
+        },
+        "Rotation": {
+          "Type": "World",
+          "Value": { "x": 0, "y": 180, "z": 0 }
+        }
+      }
+    },
+    {
+      "Path": "Chunks[?(@.Name == 'Chunk_EncounterBoundary')].Children[?(@.Name == 'EncounterBoundaryRect')]",
+      "Action": "ObjectMerge",
+      "Value": {
+        "Name": "EncounterBoundaryRect",
+        "Position": {
+          "Type": "World",
+          "Value": { "x": 15, "y": 50, "z": 450 }
+        },
+        "Width": 900,
+        "Length": 1024
+      }
+    }
+  ]
+}

--- a/MissionControl/contractTypeBuilds/HeroDuel/story3_lunar_craters.jsonc
+++ b/MissionControl/contractTypeBuilds/HeroDuel/story3_lunar_craters.jsonc
@@ -1,0 +1,49 @@
+// This file overrides the contract type 'common.json' file with map specific values (such as locations and rotations)
+{
+  "EncounterLayerId": "mapStory_StoryEncounter3_mMoon.12c7d56e-f79d-48f2-a2c4-b447138c3491",
+  "Overrides": [
+    {
+      "Path": "Chunks[?(@.Name == 'Chunk_PlayerLance')].Children[?(@.Name == 'Spawner_PlayerLance')]",
+      "Action": "ObjectMerge",
+      "Value": {
+        "Name": "Spawner_PlayerLance",
+        "Position": {
+          "Type": "World",
+          "Value": { "x": -300, "y": 140, "z": 20 }
+        },
+        "Rotation": {
+          "Type": "World",
+          "Value": { "x": 0, "y": 30, "z": 0 }
+        }
+      }
+    },
+    {
+      "Path": "Chunks[?(@.Name == 'Chunk_DestroyWholeLance')].Children[?(@.Name == 'Lance_Enemy_OpposingForce')]",
+      "Action": "ObjectMerge",
+      "Value": {
+        "Name": "Lance_Enemy_OpposingForce",
+        "Position": {
+          "Type": "World",
+          "Value": { "x": 230, "y": 150, "z": 420 }
+        },
+        "Rotation": {
+          "Type": "World",
+          "Value": { "x": 0, "y": 270, "z": 0 }
+        }
+      }
+    },
+    {
+      "Path": "Chunks[?(@.Name == 'Chunk_EncounterBoundary')].Children[?(@.Name == 'EncounterBoundaryRect')]",
+      "Action": "ObjectMerge",
+      "Value": {
+        "Name": "EncounterBoundaryRect",
+        "Position": {
+          "Type": "World",
+          "Value": { "x": 15, "y": 50, "z": 450 }
+        },
+        "Width": 900,
+        "Length": 1024
+      }
+    }
+  ]
+}

--- a/MissionControl/contractTypeBuilds/HeroDuel/story6_glacier_open_area.jsonc
+++ b/MissionControl/contractTypeBuilds/HeroDuel/story6_glacier_open_area.jsonc
@@ -1,0 +1,49 @@
+// This file overrides the contract type 'common.json' file with map specific values (such as locations and rotations)
+{
+  "EncounterLayerId": "mapStory_StoryEncounter6_iGlc.c70c1e8c-541e-49ea-94e3-a1f6fe3c8b56",
+  "Overrides": [
+    {
+      "Path": "Chunks[?(@.Name == 'Chunk_PlayerLance')].Children[?(@.Name == 'Spawner_PlayerLance')]",
+      "Action": "ObjectMerge",
+      "Value": {
+        "Name": "Spawner_PlayerLance",
+        "Position": {
+          "Type": "World",
+          "Value": { "x": -200, "y": 250, "z": 500 }
+        },
+        "Rotation": {
+          "Type": "World",
+          "Value": { "x": 0, "y": 60, "z": 0 }
+        }
+      }
+    },
+    {
+      "Path": "Chunks[?(@.Name == 'Chunk_DestroyWholeLance')].Children[?(@.Name == 'Lance_Enemy_OpposingForce')]",
+      "Action": "ObjectMerge",
+      "Value": {
+        "Name": "Lance_Enemy_OpposingForce",
+        "Position": {
+          "Type": "World",
+          "Value": { "x": 250, "y": 175, "z": 700 }
+        },
+        "Rotation": {
+          "Type": "World",
+          "Value": { "x": 0, "y": 250, "z": 0 }
+        }
+      }
+    },
+    {
+      "Path": "Chunks[?(@.Name == 'Chunk_EncounterBoundary')].Children[?(@.Name == 'EncounterBoundaryRect')]",
+      "Action": "ObjectMerge",
+      "Value": {
+        "Name": "EncounterBoundaryRect",
+        "Position": {
+          "Type": "World",
+          "Value": { "x": 15, "y": 350, "z": 650 }
+        },
+        "Width": 700,
+        "Length": 600
+      }
+    }
+  ]
+}

--- a/MissionControl/contractTypeBuilds/HeroDuel/story9_highlandspring_arena.jsonc
+++ b/MissionControl/contractTypeBuilds/HeroDuel/story9_highlandspring_arena.jsonc
@@ -1,0 +1,49 @@
+// This file overrides the contract type 'common.json' file with map specific values (such as locations and rotations)
+{
+  "EncounterLayerId": "mapStory_StoryEncounter9_vHigh.d9b711ac-2a6b-4236-86a8-61762a08f1ef",
+  "Overrides": [
+    {
+      "Path": "Chunks[?(@.Name == 'Chunk_PlayerLance')].Children[?(@.Name == 'Spawner_PlayerLance')]",
+      "Action": "ObjectMerge",
+      "Value": {
+        "Name": "Spawner_PlayerLance",
+        "Position": {
+          "Type": "World",
+          "Value": { "x": -90, "y": 86, "z": 40 }
+        },
+        "Rotation": {
+          "Type": "World",
+          "Value": { "x": 0, "y": 30, "z": 0 }
+        }
+      }
+    },
+    {
+      "Path": "Chunks[?(@.Name == 'Chunk_DestroyWholeLance')].Children[?(@.Name == 'Lance_Enemy_OpposingForce')]",
+      "Action": "ObjectMerge",
+      "Value": {
+        "Name": "Lance_Enemy_OpposingForce",
+        "Position": {
+          "Type": "World",
+          "Value": { "x": 0, "y": 60, "z": 650 }
+        },
+        "Rotation": {
+          "Type": "World",
+          "Value": { "x": 0, "y": 180, "z": 0 }
+        }
+      }
+    },
+    {
+      "Path": "Chunks[?(@.Name == 'Chunk_EncounterBoundary')].Children[?(@.Name == 'EncounterBoundaryRect')]",
+      "Action": "ObjectMerge",
+      "Value": {
+        "Name": "EncounterBoundaryRect",
+        "Position": {
+          "Type": "World",
+          "Value": { "x": 15, "y": 50, "z": 450 }
+        },
+        "Width": 900,
+        "Length": 1024
+      }
+    }
+  ]
+}

--- a/MissionControl/overrides/encounterLayers/heroduel/encounterLayer_heroDuel.mapArena_deathValley_aDes.json
+++ b/MissionControl/overrides/encounterLayers/heroduel/encounterLayer_heroDuel.mapArena_deathValley_aDes.json
@@ -1,0 +1,12 @@
+{
+  "EncounterLayerID": "mapArena_deathValley_aDes.73b9ebfe-b62b-4ffb-87b9-a0191d2530b3",
+  "MapID": "mapArena_deathValley_aDes",
+  "Name": "encMC_HeroDuel_OpenArea",
+  "FriendlyName": "Hero Duel - Open Area",
+  "Description": "Player must kill the duel target.",
+  "BattleValue": "0",
+  "ContractTypeID": "10000",
+  "EncounterLayerGUID": "73b9ebfe-b62b-4ffb-87b9-a0191d2530b3",
+  "TagSetID": "mapArena_deathValley_aDes.73b9ebfe-b62b-4ffb-87b9-a0191d2530b3",
+  "IncludeInBuild": "1"
+}

--- a/MissionControl/overrides/encounterLayers/heroduel/encounterLayer_heroDuel.mapStory_StoryEncounter3_mMoon_craters.json
+++ b/MissionControl/overrides/encounterLayers/heroduel/encounterLayer_heroDuel.mapStory_StoryEncounter3_mMoon_craters.json
@@ -1,0 +1,12 @@
+{
+  "EncounterLayerID": "mapStory_StoryEncounter3_mMoon.12c7d56e-f79d-48f2-a2c4-b447138c3491",
+  "MapID": "mapStory_StoryEncounter3_mMoon",
+  "Name": "encMC_HeroDuel_CrashSite",
+  "FriendlyName": "Hero Duel - Crash Site",
+  "Description": "Player must kill the duel target.",
+  "BattleValue": "0",
+  "ContractTypeID": "10000",
+  "EncounterLayerGUID": "12c7d56e-f79d-48f2-a2c4-b447138c3491",
+  "TagSetID": "mapStory_StoryEncounter3_mMoon.12c7d56e-f79d-48f2-a2c4-b447138c3491",
+  "IncludeInBuild": "1"
+}

--- a/MissionControl/overrides/encounterLayers/heroduel/encounterLayer_heroDuel.mapStory_StoryEncounter6_iGlc_open_area.json
+++ b/MissionControl/overrides/encounterLayers/heroduel/encounterLayer_heroDuel.mapStory_StoryEncounter6_iGlc_open_area.json
@@ -1,0 +1,12 @@
+{
+  "EncounterLayerID": "mapStory_StoryEncounter6_iGlc.c70c1e8c-541e-49ea-94e3-a1f6fe3c8b56",
+  "MapID": "mapStory_StoryEncounter6_iGlc",
+  "Name": "encMC_HeroDuel_OpenArea",
+  "FriendlyName": "Hero Duel - Open Area",
+  "Description": "Player must kill the duel target.",
+  "BattleValue": "0",
+  "ContractTypeID": "10000",
+  "EncounterLayerGUID": "c70c1e8c-541e-49ea-94e3-a1f6fe3c8b56",
+  "TagSetID": "mapStory_StoryEncounter6_iGlc.c70c1e8c-541e-49ea-94e3-a1f6fe3c8b56",
+  "IncludeInBuild": "1"
+}

--- a/MissionControl/overrides/encounterLayers/heroduel/encounterLayer_heroDuel.mapStory_StoryEncounter9_vHigh.json
+++ b/MissionControl/overrides/encounterLayers/heroduel/encounterLayer_heroDuel.mapStory_StoryEncounter9_vHigh.json
@@ -1,0 +1,12 @@
+{
+  "EncounterLayerID": "mapStory_StoryEncounter9_vHigh.d9b711ac-2a6b-4236-86a8-61762a08f1ef",
+  "MapID": "mapStory_StoryEncounter9_vHigh",
+  "Name": "encMC_HeroDuel",
+  "FriendlyName": "Hero Duel",
+  "Description": "Player must kill the duel target.",
+  "BattleValue": "0",
+  "ContractTypeID": "10000",
+  "EncounterLayerGUID": "d9b711ac-2a6b-4236-86a8-61762a08f1ef",
+  "TagSetID": "mapStory_StoryEncounter9_vHigh.d9b711ac-2a6b-4236-86a8-61762a08f1ef",
+  "IncludeInBuild": "1"
+}

--- a/MissionControl/overrides/encounterLayers/heroduel/encounterLayer_heroDuel.mapStory_StoryEncounter9_vHigh_arena.json
+++ b/MissionControl/overrides/encounterLayers/heroduel/encounterLayer_heroDuel.mapStory_StoryEncounter9_vHigh_arena.json
@@ -1,0 +1,12 @@
+{
+  "EncounterLayerID": "mapStory_StoryEncounter9_vHigh.d9b711ac-2a6b-4236-86a8-61762a08f1ef",
+  "MapID": "mapStory_StoryEncounter9_vHigh",
+  "Name": "encMC_HeroDuel_Arena",
+  "FriendlyName": "Hero Duel - Arena",
+  "Description": "Player must kill the duel target.",
+  "BattleValue": "0",
+  "ContractTypeID": "10000",
+  "EncounterLayerGUID": "d9b711ac-2a6b-4236-86a8-61762a08f1ef",
+  "TagSetID": "mapStory_StoryEncounter9_vHigh.d9b711ac-2a6b-4236-86a8-61762a08f1ef",
+  "IncludeInBuild": "1"
+}

--- a/MissionControl/overrides/enums/ContractType.json
+++ b/MissionControl/overrides/enums/ContractType.json
@@ -1,6 +1,23 @@
 {
   "enumerationValueList": [
     {
+      "ID" : 1000,
+      "Name" : "HeroDuel",
+      "FriendlyName" : "Hero Duel",
+      "Version" : 0,
+      "IsSinglePlayerProcedural" : false,
+      "IsStory" : true,
+      "IsRestoration" : false,
+      "CustomMusic" : null,
+      "IsMultiplayer" : false,
+      "UsesFury" : false,
+      "UsesSecondScaledStructureValues" : false,
+      "ContractRewardMultiplier" : 1,
+      "Illustration" : "uixTxrSpot_battleContract",
+      "Icon" : "uixSvgIcon_contract_Battle",
+      "IsPublished" : true
+    },
+    {
       "ID" : 10000,
       "Name" : "SoloDuel",
       "FriendlyName" : "Solo Duel",


### PR DESCRIPTION
Various small AI tweaks.

1) Treat heat damage as 2.5x rather than 2x, to better acknowledge how dangerous it is. Makes the AI use inferno SRMs a bit more, and consider enemies with flame weaponry a bit more dangerous.
2) It uses a 6% chance to hit rather than 10% chance to hit as the "only shoot one laser" threshold. In practice this makes only a small difference, it still won't produce heat in search of an unlikely hit, but it's at least a little less dumb about it.
3) It tries slightly harder to get in the rear arc when sprinting. Bugz.
4) Doesn't care as much about getting LOS to every enemy, just wants LOS to its target. More likely to stay in fortified positions.

Overall these are fairly small changes - the AI isn't drastically smarter or anything, behaves almost the same.