### PR TITLE
escort contract fix

### DIFF
--- a/BT Advanced Contracts/contract/ambushconvoy/2/AmbushConvoy_GuerrillaInterception.json
+++ b/BT Advanced Contracts/contract/ambushconvoy/2/AmbushConvoy_GuerrillaInterception.json
@@ -955,7 +955,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },
@@ -1116,7 +1116,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },

--- a/BT Advanced Contracts/contract/ambushconvoy/2/AmbushConvoy_HostileAcquisitions.json
+++ b/BT Advanced Contracts/contract/ambushconvoy/2/AmbushConvoy_HostileAcquisitions.json
@@ -956,7 +956,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },
@@ -1117,7 +1117,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },

--- a/BT Advanced Contracts/contract/ambushconvoy/2/AmbushConvoy_InterceptedEvacuation.json
+++ b/BT Advanced Contracts/contract/ambushconvoy/2/AmbushConvoy_InterceptedEvacuation.json
@@ -951,7 +951,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },

--- a/BT Advanced Contracts/contract/ambushconvoy/2/AmbushConvoy_Interdiction.json
+++ b/BT Advanced Contracts/contract/ambushconvoy/2/AmbushConvoy_Interdiction.json
@@ -957,7 +957,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },
@@ -1118,7 +1118,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },

--- a/BT Advanced Contracts/contract/ambushconvoy/2/AmbushConvoy_LostSupplies.json
+++ b/BT Advanced Contracts/contract/ambushconvoy/2/AmbushConvoy_LostSupplies.json
@@ -940,7 +940,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },
@@ -1100,7 +1100,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },

--- a/BT Advanced Contracts/contract/ambushconvoy/2/AmbushConvoy_ProofOfGuilt.json
+++ b/BT Advanced Contracts/contract/ambushconvoy/2/AmbushConvoy_ProofOfGuilt.json
@@ -957,7 +957,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },

--- a/BT Advanced Contracts/contract/ambushconvoy/2/AmbushConvoy_Repossession.json
+++ b/BT Advanced Contracts/contract/ambushconvoy/2/AmbushConvoy_Repossession.json
@@ -936,7 +936,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },
@@ -1096,7 +1096,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },

--- a/BT Advanced Contracts/contract/ambushconvoy/2/AmbushConvoy_TerroristConvoy.json
+++ b/BT Advanced Contracts/contract/ambushconvoy/2/AmbushConvoy_TerroristConvoy.json
@@ -955,7 +955,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },

--- a/BT Advanced Contracts/contract/ambushconvoy/2/AmbushConvoy_ThornInTheSide.json
+++ b/BT Advanced Contracts/contract/ambushconvoy/2/AmbushConvoy_ThornInTheSide.json
@@ -957,7 +957,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },

--- a/BT Advanced Contracts/contract/ambushconvoy/2/AmbushConvoy_ThornInTheSide_Alt.json
+++ b/BT Advanced Contracts/contract/ambushconvoy/2/AmbushConvoy_ThornInTheSide_Alt.json
@@ -973,7 +973,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },

--- a/BT Advanced Contracts/contract/ambushconvoy/5/AmbushConvoy_AssetDenial_NEW.json
+++ b/BT Advanced Contracts/contract/ambushconvoy/5/AmbushConvoy_AssetDenial_NEW.json
@@ -1126,7 +1126,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },

--- a/BT Advanced Contracts/contract/ambushconvoy/5/AmbushConvoy_BackyardBarbecue.json
+++ b/BT Advanced Contracts/contract/ambushconvoy/5/AmbushConvoy_BackyardBarbecue.json
@@ -990,7 +990,7 @@
                 },
                 "spawnEffectTags" : {
                     "items" : [
-                        "spawn_poorly_maintained_25"
+                        
                     ],
                     "tagSetSourceFile" : "tags/SpawnEffectTags"
                 },

--- a/BT Advanced Contracts/contract/ambushconvoy/5/AmbushConvoy_BackyardBarbecue_Alt.json
+++ b/BT Advanced Contracts/contract/ambushconvoy/5/AmbushConvoy_BackyardBarbecue_Alt.json
@@ -957,7 +957,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_25"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },
@@ -1117,7 +1117,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_25"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },

--- a/BT Advanced Contracts/contract/ambushconvoy/5/AmbushConvoy_NippedInTheBud_NEW.json
+++ b/BT Advanced Contracts/contract/ambushconvoy/5/AmbushConvoy_NippedInTheBud_NEW.json
@@ -1105,7 +1105,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_25"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },

--- a/BT Advanced Contracts/contract/ambushconvoy/5/AmbushConvoy_Pirate_WitnessTampering.json
+++ b/BT Advanced Contracts/contract/ambushconvoy/5/AmbushConvoy_Pirate_WitnessTampering.json
@@ -1121,7 +1121,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },

--- a/BT Advanced Contracts/contract/ambushconvoy/5/AmbushConvoy_Pirate_WitnessTampering_Hard.json
+++ b/BT Advanced Contracts/contract/ambushconvoy/5/AmbushConvoy_Pirate_WitnessTampering_Hard.json
@@ -1115,7 +1115,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },

--- a/BT Advanced Contracts/contract/ambushconvoy/5/AmbushConvoy_RollingMetal.json
+++ b/BT Advanced Contracts/contract/ambushconvoy/5/AmbushConvoy_RollingMetal.json
@@ -942,7 +942,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_25"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },

--- a/BT Advanced Contracts/contract/captureescort/2/CaptureEscort_AbortedColony.json
+++ b/BT Advanced Contracts/contract/captureescort/2/CaptureEscort_AbortedColony.json
@@ -1012,7 +1012,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },
@@ -1172,7 +1172,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },
@@ -1333,7 +1333,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },

--- a/BT Advanced Contracts/contract/captureescort/2/CaptureEscort_AmmoConvoy.json
+++ b/BT Advanced Contracts/contract/captureescort/2/CaptureEscort_AmmoConvoy.json
@@ -1019,7 +1019,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },
@@ -1179,7 +1179,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },
@@ -1340,7 +1340,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },

--- a/BT Advanced Contracts/contract/captureescort/2/CaptureEscort_CivilianExtraction.json
+++ b/BT Advanced Contracts/contract/captureescort/2/CaptureEscort_CivilianExtraction.json
@@ -1160,7 +1160,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },
@@ -1321,7 +1321,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },

--- a/BT Advanced Contracts/contract/captureescort/2/CaptureEscort_Humanitarians.json
+++ b/BT Advanced Contracts/contract/captureescort/2/CaptureEscort_Humanitarians.json
@@ -1012,7 +1012,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },
@@ -1173,7 +1173,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },
@@ -1334,7 +1334,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },

--- a/BT Advanced Contracts/contract/captureescort/2/CaptureEscort_InsurrectionProtection.json
+++ b/BT Advanced Contracts/contract/captureescort/2/CaptureEscort_InsurrectionProtection.json
@@ -1019,7 +1019,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },
@@ -1180,7 +1180,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },
@@ -1341,7 +1341,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },

--- a/BT Advanced Contracts/contract/captureescort/2/CaptureEscort_PriceOfDiscretion.json
+++ b/BT Advanced Contracts/contract/captureescort/2/CaptureEscort_PriceOfDiscretion.json
@@ -1024,7 +1024,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },
@@ -1185,7 +1185,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },
@@ -1346,7 +1346,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },

--- a/BT Advanced Contracts/contract/captureescort/2/CaptureEscort_ShowOfForce.json
+++ b/BT Advanced Contracts/contract/captureescort/2/CaptureEscort_ShowOfForce.json
@@ -1017,7 +1017,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },
@@ -1177,7 +1177,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },
@@ -1338,7 +1338,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },

--- a/BT Advanced Contracts/contract/captureescort/2/CaptureEscort_SupplyConvoy.json
+++ b/BT Advanced Contracts/contract/captureescort/2/CaptureEscort_SupplyConvoy.json
@@ -1018,7 +1018,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },
@@ -1179,7 +1179,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },
@@ -1340,7 +1340,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },

--- a/BT Advanced Contracts/contract/captureescort/5/CaptureEscort_Appearances.json
+++ b/BT Advanced Contracts/contract/captureescort/5/CaptureEscort_Appearances.json
@@ -1192,7 +1192,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },

--- a/BT Advanced Contracts/contract/captureescort/5/CaptureEscort_GrandTheftAuto_Alt.json
+++ b/BT Advanced Contracts/contract/captureescort/5/CaptureEscort_GrandTheftAuto_Alt.json
@@ -883,7 +883,7 @@
                 },
                 "spawnEffectTags" : {
                     "items" : [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile" : "tags/SpawnEffectTags"
                 },

--- a/BT Advanced Contracts/contract/captureescort/5/CaptureEscort_PenitentJustice.json
+++ b/BT Advanced Contracts/contract/captureescort/5/CaptureEscort_PenitentJustice.json
@@ -1178,7 +1178,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },
@@ -1339,7 +1339,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },

--- a/BT Advanced Contracts/contract/captureescort/5/CaptureEscort_ProofOfGuilt.json
+++ b/BT Advanced Contracts/contract/captureescort/5/CaptureEscort_ProofOfGuilt.json
@@ -1031,7 +1031,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },

--- a/BT Advanced Contracts/contract/captureescort/5/CaptureEscort_ProtectTheMechs_NEW.json
+++ b/BT Advanced Contracts/contract/captureescort/5/CaptureEscort_ProtectTheMechs_NEW.json
@@ -850,7 +850,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_75"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },
@@ -1022,7 +1022,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_50"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },

--- a/BT Advanced Contracts/contract/captureescort/5/CaptureEscort_ThePrisoner.json
+++ b/BT Advanced Contracts/contract/captureescort/5/CaptureEscort_ThePrisoner.json
@@ -1034,7 +1034,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_25"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },
@@ -1194,7 +1194,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_25"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },
@@ -1354,7 +1354,7 @@
                 },
                 "spawnEffectTags": {
                     "items": [
-                        "spawn_poorly_maintained_25"
+                        
                     ],
                     "tagSetSourceFile": "tags/SpawnEffectTags"
                 },


### PR DESCRIPTION
remove the various spawn_poorly_maintained tags from spanws, all premission damage to OpFor will be down to FieldRepairs