### PR TITLE
Monster quirk no longer salvageable

### DIFF
--- a/BT Advanced Mech Quirks/upgrade/Gear_Quirk_HardenedCockpit_Monster.json
+++ b/BT Advanced Mech Quirks/upgrade/Gear_Quirk_HardenedCockpit_Monster.json
@@ -16,6 +16,14 @@
                 "IsCockpit"
             ]
         },
+		"Flags": {
+			"flags": [
+				"default",
+				"not_broken",
+				"no_salvage",
+				"autorepair"
+			]
+		},
         "InventorySorter": {
             "SortKey": "00202"
         }
@@ -153,7 +161,8 @@
     ],
     "ComponentTags": {
         "items": [
-            "component_type_stock"
+            "component_type_stock",
+			"BLACKLISTED"
         ],
         "tagSetSourceFile": ""
     }


### PR DESCRIPTION
added Blacklisted tag, and flags to stop it from being salvageable etc