### PR TITLE
Rare ammo shop fix

### DIFF
--- a/DynamicShops/data/BTA_Ammo_Rare_1.csv
+++ b/DynamicShops/data/BTA_Ammo_Rare_1.csv
@@ -21,7 +21,7 @@ Ammo_AmmunitionBox_Precision_AC20,AmmunitionBox,2,6
 Ammo_AmmunitionBox_Precision_AC5,AmmunitionBox,2,6
 Ammo_AmmunitionBox_Sabot_AC20,AmmunitionBox,2,6
 Ammo_AmmunitionBox_Sabot_AC2,AmmunitionBox,2,6
-Ammo_AmmunitionBox_Sabot_AC20,AmmunitionBox,2,6
+Ammo_AmmunitionBox_Sabot_AC10,AmmunitionBox,2,6
 Ammo_AmmunitionBox_Sabot_AC5,AmmunitionBox,2,6
 Ammo_AmmunitionBox_Ultra_AC10,AmmunitionBox,2,7
 Ammo_AmmunitionBox_Ultra_AC2,AmmunitionBox,2,7


### PR DESCRIPTION
was missing the AC10 sabot, replaced one of the twice listed AC20 ssbot with the 10