### PR TITLE
maginot line exclusion fixes

### DIFF
--- a/BT Advanced Contracts/contract/simplebattle/2/SimpleBattle_MaginotLine_NEW.json
+++ b/BT Advanced Contracts/contract/simplebattle/2/SimpleBattle_MaginotLine_NEW.json
@@ -23,9 +23,12 @@
             },
             "ExclusionTags": {
                 "items": [
-                    "planet_other_empty",
-                    "planet_climate_tropical"
-                ],
+					"planet_other_empty",
+					"planet_climate_tropical",
+					"planet_climate_terran",
+					"planet_climate_water",
+					"planet_other_gamesworld"
+				],
                 "tagSetSourceFile": ""
             },
             "RequirementComparisons": [

--- a/Primitive Mechs/mech/mechdef_bellerophon_BEL-1X.json
+++ b/Primitive Mechs/mech/mechdef_bellerophon_BEL-1X.json
@@ -147,7 +147,7 @@
 		},
 		{
 			"MountedLocation": "CenterTorso",
-			"ComponentDefID": "emod_engine_cooling_1",
+			"ComponentDefID": "emod_engine_cooling",
 			"SimGameUID": null,
 			"ComponentDefType": "HeatSink",
 			"HardpointSlot": -1,
@@ -312,6 +312,17 @@
 		},
 		{
 			"MountedLocation": "RightTorso",
+			"ComponentDefID": "Gear_HeatSink_Generic_Standard",
+			"SimGameUID": null,
+			"ComponentDefType": "HeatSink",
+			"HardpointSlot": -1,
+			"GUID": null,
+			"DamageLevel": "Functional",
+			"prefabName": null,
+			"hasPrefabName": false
+		},
+		{
+			"MountedLocation": "CenterTorso",
 			"ComponentDefID": "Gear_HeatSink_Generic_Standard",
 			"SimGameUID": null,
 			"ComponentDefType": "HeatSink",


### PR DESCRIPTION
should stop the contract appearing on planets that would cause the turrets to appear underground