### PR TITLE
Update Tank_Coolant_System.json

### DIFF
--- a/VIPAdvanced/TankEngines/Tank_Coolant_System.json
+++ b/VIPAdvanced/TankEngines/Tank_Coolant_System.json
@@ -1,15 +1,10 @@
 {
 	"Custom": {
-		"BonusDescriptions": {
-			"Bonuses": [
-				"CoolingSystemDHS"
-			]
-		},
 		"EngineHeatBlock": {
 			"HeatSinkCount": 0
 		},
 		"Cooling": {
-			"HeatSinkDefId": "Gear_HeatSink_Generic_Double"
+			"HeatSinkDefId": "Gear_HeatSink_Generic_Standard"
 		},
 		"WorkOrderCosts": {
 			"Default": {
@@ -53,8 +48,8 @@
 		"Model": "Cooling System",
 		"UIName": "Coolant",
 		"Id": "Tank_Coolant_System",
-		"Name": "DHS Engine Kit",
-		"Details": "Converts an SHS engine to DHS. A Mech' <b>Cooling System</b> provides heat dissipation for components inside the mech and compatible extension points for additional heat sinks throughout the mech. It differs from the closed cooling system of the engine.",
+		"Name": "Cooling",
+		"Details": "Basic engine cooling system",
 		"Icon": "uixSvgIcon_equipment_Heatsink"
 	},
 	"BonusValueA": "",


### PR DESCRIPTION
should be a shs not dhs, should mostly handle tank weights, no drop warnings for combat and only see them in skirmish mechbay