### PR TITLE
Removed reference to ballistics in refire reduction traits

### DIFF
--- a/BT Advanced Core/StreamingAssets/data/abilities/Traits/TraitDefRefireReduceOne.json
+++ b/BT Advanced Core/StreamingAssets/data/abilities/Traits/TraitDefRefireReduceOne.json
@@ -1,0 +1,42 @@
+{
+	"Description" : {
+		"Id" : "TraitDefRefireReduceOne",
+		"Name" : "Reduced Recoil",
+		"Details" : "PASSIVE: 'Mechs piloted by this MechWarrior have their recoil penalties reduced by 1.",
+		"Icon" : "uixSvgIcon_ability_mastertactician"
+	},
+	"Type" : "RefireReduction",
+	"ShortDesc" : "-1 Recoil Penalty",
+    "DisplayParams" : "ShowInPilotToolTip",
+	"ActivationTime" : "Passive",
+	"EffectData" :
+	[
+		{
+			"durationData" :
+			{
+				"duration" : -1
+			},
+			"targetingData" : 
+			{
+				"effectTriggerType" : "OnActivation",
+				"effectTargetType" : "Creator"
+			},
+			"effectType" : "StatisticEffect",
+			"Description" :
+			{
+				"Id" : "TraitDefIndirectReduceOne",
+				"Name" : "Reduced Recoil",
+				"Details" : "Recoil penalties reduced by 1",
+				"Icon" : "uixSvgIcon_ability_mastertactician"
+			},
+			"statisticData" : 
+			{
+				"targetCollection" : "Weapon",
+				"statName" : "RefireModifier",
+				"operation" : "Int_Add",
+				"modValue" : "-1",
+				"modType" : "System.Int32"
+			}
+		}
+	]
+}

--- a/BT Advanced Core/StreamingAssets/data/abilities/Traits/TraitDefRefireReduceTwo.json
+++ b/BT Advanced Core/StreamingAssets/data/abilities/Traits/TraitDefRefireReduceTwo.json
@@ -1,0 +1,42 @@
+{
+	"Description" : {
+		"Id" : "TraitDefRefireReduceTwo",
+		"Name" : "Reduced Recoil",
+		"Details" : "PASSIVE: 'Mechs piloted by this MechWarrior have their recoil penalties reduced by 1.",
+		"Icon" : "uixSvgIcon_ability_mastertactician"
+	},
+	"Type" : "RefireReduction",
+	"ShortDesc" : "-2 Recoil Penalty",
+    "DisplayParams" : "ShowInPilotToolTip",
+	"ActivationTime" : "Passive",
+	"EffectData" :
+	[
+		{
+			"durationData" :
+			{
+				"duration" : -1
+			},
+			"targetingData" : 
+			{
+				"effectTriggerType" : "OnActivation",
+				"effectTargetType" : "Creator"
+			},
+			"effectType" : "StatisticEffect",
+			"Description" :
+			{
+				"Id" : "TraitDefIndirectReduceOne",
+				"Name" : "Reduced Recoil",
+				"Details" : "Recoil penalties reduced by 1",
+				"Icon" : "uixSvgIcon_ability_mastertactician"
+			},
+			"statisticData" : 
+			{
+				"targetCollection" : "Weapon",
+				"statName" : "RefireModifier",
+				"operation" : "Int_Add",
+				"modValue" : "-1",
+				"modType" : "System.Int32"
+			}
+		}
+	]
+}


### PR DESCRIPTION
Removed ballistic from descriptions so it just says recoil. Hopefully more obvious that it applies to all weapons now.

User complained about the trait's tooltip being confusing because it specifically referred to ballistic recoil. Pretty sure that's just a vestige of vanilla HBS where the only weapons that had recoil were ballistic. 