### PR TITLE
CBTBE tweak

### DIFF
--- a/CBTBehaviorsEnhanced/mod.json
+++ b/CBTBehaviorsEnhanced/mod.json
@@ -150,15 +150,15 @@
 
             "AllowMeleeFromSprint" : true,
             "ProneTargetAttackModifier" : -2,
-            "FilterCanUseInMeleeWeaponsByAttack" : true,
-            "WalkAttackAdditionalRange" : 24.0
+            "FilterCanUseInMeleeWeaponsByAttack" : true
         },
         
         "Move" : {
             "MinimumMove" : 40.0,
             "RunMulti" : 1.5,
             "FallAfterRunChance" : 0.30,
-            "FallAfterJumpChance" : 0.30
+            "FallAfterJumpChance" : 0.30,
+			"MPMetersPerHex": 28.0
         },
         
         "Piloting" : {


### PR DESCRIPTION
WalkAttackAdditionalRange was removed from CBTBE in update, added MPMetersPerHex to match ME's MovementPointDistanceMultiplier, defaults to the base value of 24 if not listed in json