### PR TITLE
Various Indirect Fire Bonus Fixes

### DIFF
--- a/Abilifier/abilities/AbilityDefRevostaeIndirect.json
+++ b/Abilifier/abilities/AbilityDefRevostaeIndirect.json
@@ -1,8 +1,8 @@
 {
 	"Description": {
-		"Id": "AbilityDefRevostaeMissile",
+		"Id": "AbilityDefRevostaeIndirect",
 		"Name": "HOLD LOCKS PLEASE",
-		"Details": "PASSIVE: Revostae's indirect accuracy with missile weapons is increased by 4 but his direct accuracy with missile weapons is decreased by 2.",
+		"Details": "PASSIVE: Revostae's indirect accuracy is increased by 4 but his direct accuracy is decreased by 2.",
 		"Icon": "on-target"
 	},
 	"DisplayParams": "ShowInMWTRay",
@@ -20,9 +20,9 @@
             },
             "effectType" : "StatisticEffect",
             "Description" : {
-                "Id" : "AbilityDefRevostaeMissile_DirectAccuracy",
-                "Name" : "Direct Missile Accuracy Decreased",
-                "Details" : "Direct fire missile attacks gain -2 accuracy.",
+                "Id" : "AbilityDefRevostaeIndirect_DirectAccuracy",
+                "Name" : "Direct Fire Accuracy Decreased",
+                "Details" : "Direct fire weapon accuracy suffer a +2 penalty.",
                 "Icon" : "on-target"
             },
             "nature" : "Buff",
@@ -30,12 +30,7 @@
 				"modType": "System.Single",
 				"modValue": "2.0",
 				"operation": "Float_Add",
-				"statName": "AccuracyModifier",
-				"targetAmmoCategory": "NotSet",
-				"targetCollection": "Weapon",
-				"targetWeaponCategory": "Missile",
-				"targetWeaponSubType": "NotSet",
-				"targetWeaponType": "NotSet"
+				"statName": "AccuracyModifier"
 			}
         },
 		{
@@ -50,9 +45,9 @@
             },
             "effectType": "StatisticEffect",
             "Description": {
-                "Id": "AbilityDefRevostaeMissile_IndirectAccuracy",
-                "Name": "Indirect Missile Accuracy Increased",
-                "Details": "Indirect missile accuracy gains a +4 bonus.",
+                "Id": "AbilityDefRevostaeIndirect_IndirectAccuracy",
+                "Name": "Indirect Accuracy Increased",
+                "Details": "Indirect weapon accuracy gains a +4 bonus.",
                 "Icon": "on-target"
             },
             "nature": "Buff",
@@ -60,12 +55,7 @@
                 "statName": "ToHitIndirectModifier",
                 "operation": "Float_Add",
                 "modValue": "-6.0",
-                "modType": "System.Single",
-				"targetAmmoCategory": "NotSet",
-				"targetCollection": "Weapon",
-				"targetWeaponCategory": "Missile",
-				"targetWeaponSubType": "NotSet",
-				"targetWeaponType": "NotSet"
+                "modType": "System.Single"
             }
         }
 	]

--- a/AbilityRealizer/mod.json
+++ b/AbilityRealizer/mod.json
@@ -32,7 +32,7 @@
 				"name_t-bone": ["AbilityDeftboneHunt"],
 				"name_Tex": ["AbilityDefTexHealth"],
 				"name_wulfbanes": ["AbilityDefWulfSRM"],
-				"name_Revostae": ["AbilityDefRevostaeMissile"],
+				"name_Revostae": ["AbilityDefRevostaeIndirect"],
 				"name_Turtrus": ["AbilityDefTurtrusEnergy"],
 				"name_GrampaTex": ["AbilityDefGrampaTex"],
 				"name_Shade": ["AbilityDefShadeMelee"]

--- a/BT Advanced Gear/upgrade/Gear_General_Advanced_Command_Module.json
+++ b/BT Advanced Gear/upgrade/Gear_General_Advanced_Command_Module.json
@@ -203,7 +203,7 @@
 			"effectType": "StatisticEffect",
 			"Description": {
 				"Id": "CommandModule-IndirectAccuracy_Add",
-				"Name": "MISSILE WEAPON INDIRECT HIT CHANCE IMPROVED",
+				"Name": "INDIRECT HIT CHANCE IMPROVED",
 				"Details": "Indirect fire penalties reduced by 2.",
 				"Icon": "uixSvgIcon_equipment_Cockpit"
 			},
@@ -216,11 +216,6 @@
 				"modValue": "-2.0",
 				"modType": "System.Single",
 				"additionalRules": "NotSet",
-				"targetCollection": "Weapon",
-				"targetWeaponCategory": "Missile",
-				"targetWeaponType": "NotSet",
-				"targetAmmoCategory": "NotSet",
-				"targetWeaponSubType": "NotSet"
 			},
 			"tagData": null,
 			"floatieData": null,

--- a/BT Advanced Pilots/pilot/pilot_wiki_Revostae.json
+++ b/BT Advanced Pilots/pilot/pilot_wiki_Revostae.json
@@ -28,7 +28,7 @@
     "Morale": 0,
     "Voice": "m_pro05_rick",
     "abilityDefNames": [
-		"AbilityDefRevostaeMissile",
+		"AbilityDefRevostaeIndirect",
         "AbilityDefT5Aa",
 		"AbilityDefT8A",
 		"TraitDefIndirectReduceOne",

--- a/MechengineerGear/data/basic/internals/Gear_Cockpit_CommandConsole.json
+++ b/MechengineerGear/data/basic/internals/Gear_Cockpit_CommandConsole.json
@@ -230,8 +230,8 @@
 			"effectType": "StatisticEffect",
 			"Description": {
 				"Id": "StatusEffect-IndirectAccuracy_Add-T1",
-				"Name": "MISSILE WEAPON INDIRECT HIT CHANCE IMPROVED",
-				"Details": "Indirect fire penalties reduced by 1.",
+				"Name": "INDIRECT HIT CHANCE IMPROVED",
+				"Details": "Indirect fire penalties reduced by 2.",
 				"Icon": "uixSvgIcon_equipment_Cockpit"
 			},
 			"nature": "Buff",
@@ -243,11 +243,6 @@
 				"modValue": "-2.0",
 				"modType": "System.Single",
 				"additionalRules": "NotSet",
-				"targetCollection": "Weapon",
-				"targetWeaponCategory": "Missile",
-				"targetWeaponType": "NotSet",
-				"targetAmmoCategory": "NotSet",
-				"targetWeaponSubType": "NotSet"
 			},
 			"tagData": null,
 			"floatieData": null,

--- a/MechengineerGear/data/basic/targetTrackingSystem/Gear_TargetingTrackingSystem_I3F1.json
+++ b/MechengineerGear/data/basic/targetTrackingSystem/Gear_TargetingTrackingSystem_I3F1.json
@@ -66,7 +66,7 @@
 			"Description": {
 				"Id": "StatusEffect-I3F100",
 				"Name": "Indirect Fire Improved",
-				"Details": "Indirect Missiles Attacks gain +1 accuracy.",
+				"Details": "Indirect Attacks gain +1 accuracy.",
 				"Icon": "AdvancedTC"
 			},
 			"nature": "Buff",

--- a/MechengineerGear/data/basic/targetTrackingSystem/Gear_TargetingTrackingSystem_I3F2.json
+++ b/MechengineerGear/data/basic/targetTrackingSystem/Gear_TargetingTrackingSystem_I3F2.json
@@ -66,7 +66,7 @@
 			"Description": {
 				"Id": "StatusEffect-I3F200",
 				"Name": "Indirect Fire Improved",
-				"Details": "Indirect Missiles Attacks gain +2 accuracy.",
+				"Details": "Indirect Attacks gain +2 accuracy.",
 				"Icon": "AdvancedTC"
 			},
 			"nature": "Buff",

--- a/MechengineerGear/data/basic/targetTrackingSystem/Gear_TargetingTrackingSystem_I3F3.json
+++ b/MechengineerGear/data/basic/targetTrackingSystem/Gear_TargetingTrackingSystem_I3F3.json
@@ -66,7 +66,7 @@
 			"Description": {
 				"Id": "StatusEffect-I3F300",
 				"Name": "Indirect Fire Improved",
-				"Details": "Indirect Missiles Attacks gain +3 accuracy.",
+				"Details": "Indirect Attacks gain +3 accuracy.",
 				"Icon": "AdvancedTC"
 			},
 			"nature": "Buff",

--- a/Retrainer/mod.json
+++ b/Retrainer/mod.json
@@ -16,7 +16,7 @@
 		"AbilityDefTexHealth",
 		"AbilityDeftboneHunt",
 		"AbilityDefTurtrusEnergy",
-		"AbilityDefRevostaeMissile",
+		"AbilityDefRevostaeIndirect",
 		"AbilityDefShadeMelee",
 		"AbilityDefGrampaTex",
 		"AbilityDefCMDHunter",


### PR DESCRIPTION
Removes any weapon/ammo specifications for indirect fire accuracy as those are not compatible since Indirect Fire is an Actor constant. Also updated some buff descriptions to indicate that it affects all Indirect Fire and not just Missiles.

Renamed Revostae AbilityDef since it no longer affects only Missiles. This required updating the other JSONs that had the tag in it as well.