### PR TITLE
Circinus tanks spawn hole fix

### DIFF
--- a/VIPAdvanced/assault/vehicledef_DEMOLISHER.json
+++ b/VIPAdvanced/assault/vehicledef_DEMOLISHER.json
@@ -24,6 +24,7 @@
 			"MagistracyOfCanopus",
 			"TaurianConcordat",
 			"Outworld",
+			"Circinus",
 			"Rasalhague",
 			"Ives",
 			"JarnFolk",


### PR DESCRIPTION
fixed a repme for unit_lance_vanguard, assault tank