### PR TITLE
RCL-2 hardpoint fix

### DIFF
--- a/BT Advanced Custom Mechs/chassis/chassisdef_digking_RCL-2.json
+++ b/BT Advanced Custom Mechs/chassis/chassisdef_digking_RCL-2.json
@@ -92,6 +92,10 @@
 					"Omni": false
 				},
 				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				},
+				{
 					"WeaponMount": "Energy",
 					"Omni": false
 				}
@@ -114,6 +118,10 @@
 		{
 			"Location": "RightTorso",
 			"Hardpoints": [
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				},
 				{
 					"WeaponMount": "AntiPersonnel",
 					"Omni": false

--- a/MechengineerGear/data/exotics/internals/Gear_Gyro_Compact.json
+++ b/MechengineerGear/data/exotics/internals/Gear_Gyro_Compact.json
@@ -37,7 +37,7 @@
 		"UIName": "Gyro Compact",
 		"Id": "Gear_Gyro_Compact",
 		"Name": "Compact Gyro",
-		"Details": "The Compact Gyro is constructed from denser but more compact material and components, trading a increase in weight for halving the bulk of the device. Intended primarily to reduce the chance of penetrating fire from damaging the vital component by reducing its size, like its fusion engine counterpart, it also has the benefit of freeing up internal space in a 'Mech's normally tightly packed center torso. ",
+		"Details": "The Compact Gyro is constructed from denser but more compact material and components, trading an increase in weight for halving the bulk of the device. Intended primarily to reduce the chance of penetrating fire from damaging the vital component by reducing its size, like its fusion engine counterpart, it also has the benefit of freeing up internal space in a 'Mech's normally tightly packed center torso. ",
 		"Icon": "uixSvgIcon_equipment_Gyro"
 	},
 	"BonusValueA": "",


### PR DESCRIPTION
RCL-2 has two MGs in each side torso but only one AP hardpoint. Added an extra one on each side to fix it up.