### PR TITLE
Sabot/HEAP bonus descriptions

### DIFF
--- a/BT Advanced Core/settings/bonusDescriptions/BonusDescriptions_MechEngineer.json
+++ b/BT Advanced Core/settings/bonusDescriptions/BonusDescriptions_MechEngineer.json
@@ -4060,6 +4060,18 @@
 			"Short": "Fuel Cell Engine",
 			"Long": "Fuel Cell Engine",
 			"Full": "Fuel cell engines cannot be equipped with advanced heat sinks. Fuel cells cannot make use of any heat sink systems other than standard heat sinks. They also cannot use any e-cooling, heat bank, or heat exchanger equipment."
+		},
+		{
+			"Bonus": "InsanityDebuff",
+			"Short": "Insanity PPC Debuff",
+			"Long": "InsanityPPC Debuff {0}",
+			"Full": "The Insanity PPC scrambles Target's systems for {0} Accuracy, but unlike other PPCs the Insanity PPC's debuff stacks with itself up to twice and also stacks with other PPC debuff effects normally."
+		},
+		{
+			"Bonus": "InsanityPPC",
+			"Short": "Insanity PPC",
+			"Long": "Insanity PPC",
+			"Full": "The Insanity PPC fires a cluster of three shots, each doing significant armor, heat, and stability damage to both the main target and nearby enemies, as well as imparting a serious accuracy debuff."
 		}
 	]
 }

--- a/BT Advanced Core/settings/bonusDescriptions/BonusDescriptions_MechEngineer.json
+++ b/BT Advanced Core/settings/bonusDescriptions/BonusDescriptions_MechEngineer.json
@@ -3468,10 +3468,16 @@
 			"Full": "Sabot ammo does {0} more damage per shot"
 		},
 		{
-			"Bonus": "SabotPercent",
+			"Bonus": "SabotArmPercent",
 			"Short": "Sabot Modifier",
 			"Long": "Sabot Modifier",
-			"Full": "Sabot ammo does {0} more damage to armor and less damage to structure"
+			"Full": "Sabot ammo does {0}% more damage to armor."
+		},
+		{
+			"Bonus": "SabotStrPercent",
+			"Short": "Sabot Modifier",
+			"Long": "Sabot Modifier",
+			"Full": "Sabot ammo does {0}% less damage to structure."
 		},
 		{
 			"Bonus": "JamExplode",
@@ -4054,18 +4060,6 @@
 			"Short": "Fuel Cell Engine",
 			"Long": "Fuel Cell Engine",
 			"Full": "Fuel cell engines cannot be equipped with advanced heat sinks. Fuel cells cannot make use of any heat sink systems other than standard heat sinks. They also cannot use any e-cooling, heat bank, or heat exchanger equipment."
-		},
-		{
-			"Bonus": "InsanityDebuff",
-			"Short": "Insanity PPC Debuff",
-			"Long": "InsanityPPC Debuff {0}",
-			"Full": "The Insanity PPC scrambles Target's systems for {0} Accuracy, but unlike other PPCs the Insanity PPC's debuff stacks with itself up to twice and also stacks with other PPC debuff effects normally."
-		},
-		{
-			"Bonus": "InsanityPPC",
-			"Short": "Insanity PPC",
-			"Long": "Insanity PPC",
-			"Full": "The Insanity PPC fires a cluster of three shots, each doing significant armor, heat, and stability damage to both the main target and nearby enemies, as well as imparting a serious accuracy debuff."
 		}
 	]
 }

--- a/CustomAmmoCategories/Autocannons/Ammo_AmmunitionBox_Sabot_AC10.json
+++ b/CustomAmmoCategories/Autocannons/Ammo_AmmunitionBox_Sabot_AC10.json
@@ -18,8 +18,9 @@
 			"Bonuses": [
 				"CostPerShot: 800",
 				"AC10Ammo: 10",
-				"SabotDmg: 20",
-				"SabotPercent: 25"
+				"SabotDmg: 6",
+				"SabotArmPercent: 25",
+				"SabotStrPercent: 50"
 			]
 		},
 		"AmmoCost" : {

--- a/CustomAmmoCategories/Autocannons/Ammo_AmmunitionBox_Sabot_AC2.json
+++ b/CustomAmmoCategories/Autocannons/Ammo_AmmunitionBox_Sabot_AC2.json
@@ -18,8 +18,9 @@
 			"Bonuses": [
 				"CostPerShot: 200",
 				"AC2Ammo: 45",
-				"SabotDmg: 20",
-				"SabotPercent: 25"
+				"SabotDmg: 1",
+				"SabotArmPercent: 25",
+				"SabotStrPercent: 50"
 			]
 		},
 		"AmmoCost" : {

--- a/CustomAmmoCategories/Autocannons/Ammo_AmmunitionBox_Sabot_AC20.json
+++ b/CustomAmmoCategories/Autocannons/Ammo_AmmunitionBox_Sabot_AC20.json
@@ -18,8 +18,9 @@
 			"Bonuses": [
 				"CostPerShot: 1600",
 				"AC20Ammo: 5",
-				"SabotDmg: 20",
-				"SabotPercent: 25"
+				"SabotDmg: 10",
+				"SabotArmPercent: 25",
+				"SabotStrPercent: 50"
 			]
 		},
 		"AmmoCost" : {

--- a/CustomAmmoCategories/Autocannons/Ammo_AmmunitionBox_Sabot_AC5.json
+++ b/CustomAmmoCategories/Autocannons/Ammo_AmmunitionBox_Sabot_AC5.json
@@ -18,8 +18,9 @@
 			"Bonuses": [
 				"CostPerShot: 400",
 				"AC5Ammo: 15",
-				"SabotDmg: 20",
-				"SabotPercent: 25"
+				"SabotDmg: 4",
+				"SabotArmPercent: 25",
+				"SabotStrPercent: 50"
 			]
 		},
 		"AmmoCost" : {


### PR DESCRIPTION
Proposed fixes for the bonus damage values including splitting "SabotPercent" into SabotArmPercent and SabotStrPercent bonus values because they're not currently equal.