### PR TITLE
COR-TB tweak

### DIFF
--- a/BT Advanced Custom Mechs/mech/mechdef_corsair_COR-TB.json
+++ b/BT Advanced Custom Mechs/mech/mechdef_corsair_COR-TB.json
@@ -375,6 +375,17 @@
 		},
 		{
 			"MountedLocation": "LeftTorso",
+			"ComponentDefID": "Gear_MASC",
+			"SimGameUID": null,
+			"ComponentDefType": "Upgrade",
+			"HardpointSlot": 0,
+			"GUID": null,
+			"DamageLevel": "Functional",
+			"prefabName": null,
+			"hasPrefabName": false
+		},
+		{
+			"MountedLocation": "LeftTorso",
 			"ComponentDefID": "Ammo_AmmunitionBox_Generic_GAUSS",
 			"SimGameUID": null,
 			"ComponentDefType": "AmmunitionBox",
@@ -400,17 +411,6 @@
 			"ComponentDefID": "Ammo_AmmunitionBox_Sabot_AC5",
 			"SimGameUID": null,
 			"ComponentDefType": "AmmunitionBox",
-			"HardpointSlot": 0,
-			"GUID": null,
-			"DamageLevel": "Functional",
-			"prefabName": null,
-			"hasPrefabName": false
-		},
-		{
-			"MountedLocation": "CenterTorso",
-			"ComponentDefID": "Gear_MASC",
-			"SimGameUID": null,
-			"ComponentDefType": "Upgrade",
 			"HardpointSlot": 0,
 			"GUID": null,
 			"DamageLevel": "Functional",


### PR DESCRIPTION
Moved MASC to left torso because there wasn't enough room in the CT with the hero quirk