### PR TITLE
make bribes and loans not visible in mechbay. CustomFilters update wi…

### DIFF
--- a/BT Advanced Gear/upgrade/Gear_Bribe_Locals.json
+++ b/BT Advanced Gear/upgrade/Gear_Bribe_Locals.json
@@ -1,4 +1,9 @@
-{
+{	
+	"Custom": {
+		"Category": {
+			"CategoryID": "notused"
+		}
+	},
     "StatName": null,
     "RelativeModifier": 0,
     "AbsoluteModifier": 0,

--- a/BT Advanced Gear/upgrade/Gear_Bribe_Pirates.json
+++ b/BT Advanced Gear/upgrade/Gear_Bribe_Pirates.json
@@ -1,4 +1,9 @@
 {
+	"Custom": {
+		"Category": {
+			"CategoryID": "notused"
+		}
+	},
     "StatName": null,
     "RelativeModifier": 0,
     "AbsoluteModifier": 0,

--- a/BT Advanced Gear/upgrade/Gear_Loan_Million.json
+++ b/BT Advanced Gear/upgrade/Gear_Loan_Million.json
@@ -1,5 +1,8 @@
 {
     "Custom": {
+		"Category": {
+			"CategoryID": "notused"
+		},
         "BonusDescriptions": {
             "Bonuses": [
                 "LoanShark"

--- a/CustomFilters/mod.json
+++ b/CustomFilters/mod.json
@@ -23,6 +23,9 @@
 				"Filter": {
 					"ComponentTypes": [
 						"Weapon"
+					],
+					"NotCategories": [
+						"notused"
 					]
 				},
 				"Buttons": [
@@ -212,6 +215,9 @@
 				"Filter": {
 					"ComponentTypes": [
 						"AmmunitionBox"
+					],
+					"NotCategories": [
+						"notused"
 					]
 				},
 				"Buttons": [
@@ -231,6 +237,9 @@
 								"a/a/a/lbx",
 								"a/a/a/sg",
 								"a/a/a/rac"
+							],
+							"NotCategories": [
+								"notused"
 							]
 						}
 					},
@@ -241,6 +250,9 @@
 							"Categories": [
 								"a/a/g/gauss",
 								"w/a/g/hag"
+							],
+							"NotCategories": [
+								"notused"
 							]
 						}
 					},
@@ -253,6 +265,9 @@
 								"a/a/o/mortar",
 								"a/m/t/arrowiv",
 								"a/m/t/cruisemissile"
+							],
+							"NotCategories": [
+								"notused"
 							]
 						}
 					},
@@ -265,6 +280,9 @@
 								"a/m/s/ssrm",
 								"SRMARTIVAmmo",
 								"a/m/s/narc"
+							],
+							"NotCategories": [
+								"notused"
 							]
 						}
 					},
@@ -281,6 +299,9 @@
 								"a/m/s/vrm",
 								"a/m/l/atm",
 								"a/m/l/iatm"
+							],
+							"NotCategories": [
+								"notused"
 							]
 						}
 					},
@@ -291,6 +312,9 @@
 							"Categories": [
 								"a/e/p/plasma",
 								"a/e/l/chemical"
+							],
+							"NotCategories": [
+								"notused"
 							]
 						}
 					},
@@ -302,6 +326,9 @@
 								"a/s/a/mg",
 								"a/s/a/magshot",
 								"a/s/a/ams"
+							],
+							"NotCategories": [
+								"notused"
 							]
 						}
 					}
@@ -313,6 +340,9 @@
 					"ComponentTypes": [
 						"HeatSink",
 						"Upgrade"
+					],
+					"NotCategories": [
+						"notused"
 					]
 				},
 				"Buttons": [
@@ -327,6 +357,9 @@
 						"Filter": {
 							"Categories": [
 								"EngineCore"
+							],
+							"NotCategories": [
+								"notused"
 							]
 						}
 					},
@@ -338,7 +371,9 @@
 							"Categories": [
 								"EngineShield"
 							],
-							"NotCategories": []
+							"NotCategories": [
+								"notused"
+							]
 						}
 					},
 					{
@@ -352,6 +387,9 @@
 							],
 							"NotCategories": [
 								"EngineShield"
+							],
+							"NotCategories": [
+								"notused"
 							]
 						}
 					},
@@ -364,7 +402,8 @@
 								"EngineHeatBlock"
 							],
 							"NotCategories": [
-								"EngineShield"
+								"EngineShield",
+								"notused"
 							]
 						}
 					},
@@ -380,7 +419,8 @@
 								"EnginePart",
 								"Cooling",
 								"Special",
-								"EngineHeatBlock"
+								"EngineHeatBlock",
+								"notused"
 							]
 						}
 					},
@@ -396,6 +436,9 @@
 								"Armor",
 								"CASE",
 								"CASE2"
+							],
+							"NotCategories": [
+								"notused"
 							]
 						}
 					},
@@ -411,7 +454,8 @@
 								"Gyro"
 							],
 							"NotCategories": [
-								"Quirk"
+								"Quirk",
+								"notused"
 							]
 						}
 					},
@@ -428,6 +472,9 @@
 								"LegUpperActuator",
 								"LegLowerActuator",
 								"LegFootActuator"
+							],
+							"NotCategories": [
+								"notused"
 							]
 						}
 					},
@@ -451,7 +498,8 @@
 								"MeleeACC"
 							],
 							"NotCategories": [
-								"Quirk"
+								"Quirk",
+								"notused"
 							]
 						}
 					}
@@ -463,6 +511,9 @@
 					"ComponentTypes": [
 						"JumpJet",
 						"Upgrade"
+					],
+					"NotCategories": [
+						"notused"
 					]
 				},
 				"Buttons": [
@@ -482,6 +533,9 @@
 								"StandardJJ",
 								"ImprovedJJ",
 								"PartialWing"
+							],
+							"NotCategories": [
+								"notused"
 							]
 						}
 					},
@@ -501,7 +555,8 @@
 								"SensorsB"
 							],
 							"NotCategories": [
-								"Quirk"
+								"Quirk",
+								"notused"
 							]
 						}
 					},
@@ -527,6 +582,9 @@
 								"MimeticSystem",
 								"Chameleon",
 								"StealthX"
+							],
+							"NotCategories": [
+								"notused"
 							]
 						}
 					},
@@ -550,7 +608,8 @@
 								"PPCCAP"
 							],
 							"NotCategories": [
-								"Quirk"
+								"Quirk",
+								"notused"
 							]
 						}
 					},
@@ -567,6 +626,9 @@
 								"LegUpperActuator",
 								"LegLowerActuator",
 								"LegFootActuator"
+							],
+							"NotCategories": [
+								"notused"
 							]
 						}
 					},
@@ -587,7 +649,8 @@
 								"OmniLowerActuator"
 							],
 							"NotCategories": [
-								"Quirk"
+								"Quirk",
+								"notused"
 							]
 						}
 					},
@@ -618,7 +681,8 @@
 								"ArmHandActuator",
 								"OmniHandActuator",
 								"OmniLowerActuator",
-								"Quirk"
+								"Quirk",
+								"notused"
 							]
 						}
 					}


### PR DESCRIPTION
…ll make ANY component with "CategoryID": "notused" not visible in mechbay