### PR TITLE
Avionics turn off when knocked down

### DIFF
--- a/Community Content/upgrade/Gear_Avionics_MON.json
+++ b/Community Content/upgrade/Gear_Avionics_MON.json
@@ -5,6 +5,7 @@
 			"ActivationMessage": "AirMech",
 			"DeactivationMessage": "BattleMech",
 			"CanNotBeActivatedManualy": false,
+			"SwitchOffOnFall" : true,
 			"statusEffects": [{
 					"durationData": {
 						"duration": -1,

--- a/MechEngineer/Settings.json
+++ b/MechEngineer/Settings.json
@@ -108,6 +108,8 @@
 			"Gear_Cockpit_Generic_Standard",
 			"Gear_Cockpit_LifeSupportA_Standard",
 			"Gear_Cockpit_LifeSupportB_Standard",
+			"Gear_Cockpit_LifeSupportA_Torso",
+			"Gear_Cockpit_LifeSupportB_Torso",
 			"Gear_Cockpit_SensorsA_Standard",
 			"Gear_Cockpit_SensorsB_Standard",
 			"Gear_Gyro_Generic_Standard",

--- a/MechEngineer/Settings.json
+++ b/MechEngineer/Settings.json
@@ -108,8 +108,6 @@
 			"Gear_Cockpit_Generic_Standard",
 			"Gear_Cockpit_LifeSupportA_Standard",
 			"Gear_Cockpit_LifeSupportB_Standard",
-			"Gear_Cockpit_LifeSupportA_Torso",
-			"Gear_Cockpit_LifeSupportB_Torso",
 			"Gear_Cockpit_SensorsA_Standard",
 			"Gear_Cockpit_SensorsB_Standard",
 			"Gear_Gyro_Generic_Standard",

--- a/MechengineerGear/data/exotics/internals/Gear_Avionics_HOR.json
+++ b/MechengineerGear/data/exotics/internals/Gear_Avionics_HOR.json
@@ -5,6 +5,7 @@
 			"ActivationMessage": "AirMech",
 			"DeactivationMessage": "BattleMech",
 			"CanNotBeActivatedManualy": false,
+			"SwitchOffOnFall" : true,
 			"statusEffects": [{
 					"durationData": {
 						"duration": -1,

--- a/MechengineerGear/data/exotics/internals/Gear_Avionics_NG.json
+++ b/MechengineerGear/data/exotics/internals/Gear_Avionics_NG.json
@@ -5,6 +5,7 @@
 			"ActivationMessage": "AirMech",
 			"DeactivationMessage": "BattleMech",
 			"CanNotBeActivatedManualy": false,
+			"SwitchOffOnFall" : true,
 			"statusEffects": [{
 					"durationData": {
 						"duration": -1,

--- a/MechengineerGear/data/exotics/internals/Gear_Avionics_PHK.json
+++ b/MechengineerGear/data/exotics/internals/Gear_Avionics_PHK.json
@@ -5,6 +5,7 @@
 			"ActivationMessage": "AirMech",
 			"DeactivationMessage": "BattleMech",
 			"CanNotBeActivatedManualy": false,
+			"SwitchOffOnFall" : true,
 			"statusEffects": [{
 					"durationData": {
 						"duration": -1,

--- a/MechengineerGear/data/exotics/internals/Gear_Avionics_SCR.json
+++ b/MechengineerGear/data/exotics/internals/Gear_Avionics_SCR.json
@@ -5,6 +5,7 @@
 			"ActivationMessage": "AirMech",
 			"DeactivationMessage": "BattleMech",
 			"CanNotBeActivatedManualy": false,
+			"SwitchOffOnFall" : true,
 			"statusEffects": [{
 					"durationData": {
 						"duration": -1,

--- a/MechengineerGear/data/exotics/internals/Gear_Avionics_STG.json
+++ b/MechengineerGear/data/exotics/internals/Gear_Avionics_STG.json
@@ -5,6 +5,7 @@
 			"ActivationMessage": "AirMech",
 			"DeactivationMessage": "BattleMech",
 			"CanNotBeActivatedManualy": false,
+			"SwitchOffOnFall" : true,
 			"statusEffects": [{
 					"durationData": {
 						"duration": -1,

--- a/MechengineerGear/data/exotics/internals/Gear_Avionics_UM.json
+++ b/MechengineerGear/data/exotics/internals/Gear_Avionics_UM.json
@@ -5,6 +5,7 @@
 			"ActivationMessage": "AirMech",
 			"DeactivationMessage": "BattleMech",
 			"CanNotBeActivatedManualy": false,
+			"SwitchOffOnFall" : true,
 			"statusEffects": [{
 					"durationData": {
 						"duration": -1,

--- a/MechengineerGear/data/exotics/internals/Gear_Avionics_WSP.json
+++ b/MechengineerGear/data/exotics/internals/Gear_Avionics_WSP.json
@@ -5,6 +5,7 @@
 			"ActivationMessage": "AirMech",
 			"DeactivationMessage": "BattleMech",
 			"CanNotBeActivatedManualy": false,
+			"SwitchOffOnFall" : true,
 			"statusEffects": [{
 					"durationData": {
 						"duration": -1,


### PR DESCRIPTION
avionics now deactivate if the lam is knocked down, and should not "fly" again without the avionics being activated again