### PR TITLE
BZK-F4 assembly variant fix

### DIFF
--- a/Community Content/chassis/chassisdef_hollander_BZK-F4.json
+++ b/Community Content/chassis/chassisdef_hollander_BZK-F4.json
@@ -1,38 +1,45 @@
 {
-  "Description": {
-    "Cost": 7380000,
-    "Rarity": 6,
-    "Purchasable": true,
-    "Manufacturer": "",
-    "Model": "",
-    "UIName": "Hollander",
-    "Id": "chassisdef_hollander_BZK-F4",
-    "Name": "Hollander",
-    "Details": "The Hollander was introduced in 3054 specifically to carry a Gauss Rifle into combat and act as a sniper. The Federated Commonwealth was in dire need of a response to the fast-moving, long-range firepower of the Clan Invaders at the time, and looked at a number of light 'Mech designs featuring PPCs or LRMs as a potential answer. It was Coventry's unorthodox decision to mount such a large weapon, one that had neither the overheating or ammunition explosion drawbacks of the other designs, which won them the contract. With its single massive cannon and use of rediscovered technology, the Hollander can destroy another light 'Mech in a single hit at extreme range and threaten heavier targets easily.  The F4 subvariant was built arround the Stormbreaker short range Magshot array.",
-    "Icon": "uixTxrIcon_hollander"
-  },
-  "MovementCapDefID": "movedef_hollander_BZK-F3",
-  "PathingCapDefID": "pathingdef_light",
+	"Custom": {
+		"AssemblyVariant": {
+			"PrefabID": "Hollander",
+			"Exclude": false,
+			"Include": true
+		}
+	},
+	"Description": {
+	"Cost": 7380000,
+	"Rarity": 6,
+	"Purchasable": true,
+	"Manufacturer": "",
+	"Model": "",
+	"UIName": "Hollander",
+	"Id": "chassisdef_hollander_BZK-F4",
+	"Name": "Hollander",
+	"Details": "The Hollander was introduced in 3054 specifically to carry a Gauss Rifle into combat and act as a sniper. The Federated Commonwealth was in dire need of a response to the fast-moving, long-range firepower of the Clan Invaders at the time, and looked at a number of light 'Mech designs featuring PPCs or LRMs as a potential answer. It was Coventry's unorthodox decision to mount such a large weapon, one that had neither the overheating or ammunition explosion drawbacks of the other designs, which won them the contract. With its single massive cannon and use of rediscovered technology, the Hollander can destroy another light 'Mech in a single hit at extreme range and threaten heavier targets easily.  The F4 subvariant was built arround the Stormbreaker short range Magshot array.",
+	"Icon": "uixTxrIcon_hollander"
+	},
+	"MovementCapDefID": "movedef_hollander_BZK-F3",
+	"PathingCapDefID": "pathingdef_light",
 	"HardpointDataDefID": "hardpointdatadef_hollander",
 	"PrefabIdentifier": "chrprfmech_hollanderbase-001",
-  "PrefabBase": "hollander",
-  "Tonnage": 35,
-  "InitialTonnage": 3.5,
-  "weightClass": "LIGHT",
-  "BattleValue": 3762000,
-  "Heatsinks": 0,
-  "TopSpeed": 85,
-  "TurnRadius": 90,
-  "MaxJumpjets": 8,
-  "Stability": 100,
-  "StabilityDefenses": [
-    0,
-    0,
-    0,
-    0,
-    0,
-    0
-  ],
+	"PrefabBase": "hollander",
+	"Tonnage": 35,
+	"InitialTonnage": 3.5,
+	"weightClass": "LIGHT",
+	"BattleValue": 3762000,
+	"Heatsinks": 0,
+	"TopSpeed": 85,
+	"TurnRadius": 90,
+	"MaxJumpjets": 8,
+	"Stability": 100,
+	"StabilityDefenses": [
+	0,
+	0,
+	0,
+	0,
+	0,
+	0
+	],
 	"SpotterDistanceMultiplier": 1,
 	"VisibilityMultiplier": 1,
 	"SensorRangeMultiplier": 1,
@@ -46,169 +53,169 @@
 	"DFAToHitModifier": 0,
 	"DFASelfDamage": 45,
 	"DFAInstability": 20,
-  "Locations": [
-    {
-      "Location": "Head",
-      "Hardpoints": [
-        {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": false
-        }
-      ],
-      "Tonnage": 0,
-      "InventorySlots": 6,
-      "MaxArmor": 45,
-      "MaxRearArmor": -1,
-      "InternalStructure": 16
-    },
-    {
-      "Location": "LeftArm",
-      "Hardpoints": [
-        {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "Energy",
-          "Omni": false
-        }		
-      ],
-      "Tonnage": 0,
-      "InventorySlots": 12,
-      "MaxArmor": 60,
-      "MaxRearArmor": -1,
-      "InternalStructure": 30
-    },
-    {
-      "Location": "LeftTorso",
-      "Hardpoints": [
-        {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": false
-        }	  
+	"Locations": [
+	{
+	  "Location": "Head",
+	  "Hardpoints": [
+		{
+		  "WeaponMount": "AntiPersonnel",
+		  "Omni": false
+		}
 	  ],
-      "Tonnage": 0,
-      "InventorySlots": 12,
-      "MaxArmor": 80,
-      "MaxRearArmor": 40,
-      "InternalStructure": 40
-    },
-    {
-      "Location": "CenterTorso",
-      "Hardpoints": [],
-      "Tonnage": 0,
-      "InventorySlots": 15,
-      "MaxArmor": 110,
-      "MaxRearArmor": 55,
-      "InternalStructure": 55
-    },
-    {
-      "Location": "RightTorso",
-      "Hardpoints": [
-        {
-          "WeaponMount": "Ballistic",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "Energy",
-          "Omni": false
-        }
-      ],
-      "Tonnage": 0,
-      "InventorySlots": 12,
-      "MaxArmor": 80,
-      "MaxRearArmor": 40,
-      "InternalStructure": 40
-    },
-    {
-      "Location": "RightArm",
-      "Hardpoints": [
-        {
-          "WeaponMount": "AntiPersonnel",
-          "Omni": false
-        },
-        {
-          "WeaponMount": "Energy",
-          "Omni": false
-        }		
-      ],
-      "Tonnage": 0,
-      "InventorySlots": 12,
-      "MaxArmor": 60,
-      "MaxRearArmor": -1,
-      "InternalStructure": 30
-    },
-    {
-      "Location": "LeftLeg",
-      "Hardpoints": [],
-      "Tonnage": 0,
-      "InventorySlots": 6,
-      "MaxArmor": 80,
-      "MaxRearArmor": -1,
-      "InternalStructure": 40
-    },
-    {
-      "Location": "RightLeg",
-      "Hardpoints": [],
-      "Tonnage": 0,
-      "InventorySlots": 6,
-      "MaxArmor": 80,
-      "MaxRearArmor": -1,
-      "InternalStructure": 40
-    }
-  ],
-  "LOSSourcePositions": [
-    {
-      "x": 0,
-      "y": 10,
-      "z": 0.5
-    },
-    {
-      "x": -3,
-      "y": 9,
-      "z": -0.5
-    },
-    {
-      "x": 3,
-      "y": 9,
-      "z": -0.5
-    }
-  ],
-  "LOSTargetPositions": [
-    {
-      "x": 0,
-      "y": 10,
-      "z": 0.5
-    },
-    {
-      "x": -3,
-      "y": 9,
-      "z": -0.5
-    },
-    {
-      "x": 3,
-      "y": 9,
-      "z": -0.5
-    },
-    {
-      "x": -2.5,
-      "y": 3,
-      "z": 0.5
-    },
-    {
-      "x": 2.5,
-      "y": 3,
-      "z": 0.5
-    }
-  ],
-  "VariantName": "BZK-F4",
-  "ChassisTags": {
-    "items": [
+	  "Tonnage": 0,
+	  "InventorySlots": 6,
+	  "MaxArmor": 45,
+	  "MaxRearArmor": -1,
+	  "InternalStructure": 16
+	},
+	{
+	  "Location": "LeftArm",
+	  "Hardpoints": [
+		{
+		  "WeaponMount": "AntiPersonnel",
+		  "Omni": false
+		},
+		{
+		  "WeaponMount": "Energy",
+		  "Omni": false
+		}		
+	  ],
+	  "Tonnage": 0,
+	  "InventorySlots": 12,
+	  "MaxArmor": 60,
+	  "MaxRearArmor": -1,
+	  "InternalStructure": 30
+	},
+	{
+	  "Location": "LeftTorso",
+	  "Hardpoints": [
+		{
+		  "WeaponMount": "AntiPersonnel",
+		  "Omni": false
+		}	  
+	  ],
+	  "Tonnage": 0,
+	  "InventorySlots": 12,
+	  "MaxArmor": 80,
+	  "MaxRearArmor": 40,
+	  "InternalStructure": 40
+	},
+	{
+	  "Location": "CenterTorso",
+	  "Hardpoints": [],
+	  "Tonnage": 0,
+	  "InventorySlots": 15,
+	  "MaxArmor": 110,
+	  "MaxRearArmor": 55,
+	  "InternalStructure": 55
+	},
+	{
+	  "Location": "RightTorso",
+	  "Hardpoints": [
+		{
+		  "WeaponMount": "Ballistic",
+		  "Omni": false
+		},
+		{
+		  "WeaponMount": "Energy",
+		  "Omni": false
+		}
+	  ],
+	  "Tonnage": 0,
+	  "InventorySlots": 12,
+	  "MaxArmor": 80,
+	  "MaxRearArmor": 40,
+	  "InternalStructure": 40
+	},
+	{
+	  "Location": "RightArm",
+	  "Hardpoints": [
+		{
+		  "WeaponMount": "AntiPersonnel",
+		  "Omni": false
+		},
+		{
+		  "WeaponMount": "Energy",
+		  "Omni": false
+		}		
+	  ],
+	  "Tonnage": 0,
+	  "InventorySlots": 12,
+	  "MaxArmor": 60,
+	  "MaxRearArmor": -1,
+	  "InternalStructure": 30
+	},
+	{
+	  "Location": "LeftLeg",
+	  "Hardpoints": [],
+	  "Tonnage": 0,
+	  "InventorySlots": 6,
+	  "MaxArmor": 80,
+	  "MaxRearArmor": -1,
+	  "InternalStructure": 40
+	},
+	{
+	  "Location": "RightLeg",
+	  "Hardpoints": [],
+	  "Tonnage": 0,
+	  "InventorySlots": 6,
+	  "MaxArmor": 80,
+	  "MaxRearArmor": -1,
+	  "InternalStructure": 40
+	}
 	],
-    "tagSetSourceFile": ""
-  },
-  "StockRole": "Escort",
-  "YangsThoughts": "This Hollander variant seems to be designed as a close in escort for other longer ranged Hollanders.  The new fangled 'Stormbreaker' array can be deadly if it explodes.",
+	"LOSSourcePositions": [
+	{
+	  "x": 0,
+	  "y": 10,
+	  "z": 0.5
+	},
+	{
+	  "x": -3,
+	  "y": 9,
+	  "z": -0.5
+	},
+	{
+	  "x": 3,
+	  "y": 9,
+	  "z": -0.5
+	}
+	],
+	"LOSTargetPositions": [
+	{
+	  "x": 0,
+	  "y": 10,
+	  "z": 0.5
+	},
+	{
+	  "x": -3,
+	  "y": 9,
+	  "z": -0.5
+	},
+	{
+	  "x": 3,
+	  "y": 9,
+	  "z": -0.5
+	},
+	{
+	  "x": -2.5,
+	  "y": 3,
+	  "z": 0.5
+	},
+	{
+	  "x": 2.5,
+	  "y": 3,
+	  "z": 0.5
+	}
+	],
+	"VariantName": "BZK-F4",
+	"ChassisTags": {
+	"items": [
+	],
+	"tagSetSourceFile": ""
+	},
+	"StockRole": "Escort",
+	"YangsThoughts": "This Hollander variant seems to be designed as a close in escort for other longer ranged Hollanders.  The new fangled 'Stormbreaker' array can be deadly if it explodes.",
 	"FixedEquipment": [
 		{
 			"MountedLocation": "CenterTorso",


### PR DESCRIPTION
Pappy's Hollander wasn't compatible with other Hollanders because of the missing Custom: Assembly variant data in the chassidef. I added the missing lines in. Should be able to be use it to assemble other Hollanders now.