### PR TITLE
blackout no mechs as turrets fix

### DIFF
--- a/BT Advanced Lances/StreamingAssets/data/lance/lancedef_turret_d3_dynamic_lightTurret.json
+++ b/BT Advanced Lances/StreamingAssets/data/lance/lancedef_turret_d3_dynamic_lightTurret.json
@@ -33,6 +33,8 @@
          },
          "excludedUnitTagSet" : {
             "items" : [
+				"unit_mech",
+				"unit_vehicle"
             ],
             "tagSetSourceFile" : "Tags/UnitTags"
          },
@@ -61,6 +63,8 @@
          },
          "excludedUnitTagSet" : {
             "items" : [
+				"unit_mech",
+				"unit_vehicle"
             ],
             "tagSetSourceFile" : "Tags/UnitTags"
          },
@@ -89,6 +93,8 @@
          },
          "excludedUnitTagSet" : {
             "items" : [
+				"unit_mech",
+				"unit_vehicle"
             ],
             "tagSetSourceFile" : "Tags/UnitTags"
          },
@@ -117,6 +123,8 @@
          },
          "excludedUnitTagSet" : {
             "items" : [
+				"unit_mech",
+				"unit_vehicle"
             ],
             "tagSetSourceFile" : "Tags/UnitTags"
          },

--- a/MissionControl/overrides/contracts/blackout/Blackout_DugInDeep.json
+++ b/MissionControl/overrides/contracts/blackout/Blackout_DugInDeep.json
@@ -1054,7 +1054,9 @@
               "tagSetSourceFile": "tags/UnitTags"
             },
             "unitExcludedTagSet": {
-              "items": [],
+              "items": [
+					"unit_turret"
+				],
               "tagSetSourceFile": "tags/UnitTags"
             },
             "spawnEffectTags": {
@@ -1087,7 +1089,9 @@
               "tagSetSourceFile": "tags/UnitTags"
             },
             "unitExcludedTagSet": {
-              "items": [],
+              "items": [
+					"unit_turret"
+				],
               "tagSetSourceFile": "tags/UnitTags"
             },
             "spawnEffectTags": {
@@ -1120,7 +1124,9 @@
               "tagSetSourceFile": "tags/UnitTags"
             },
             "unitExcludedTagSet": {
-              "items": [],
+              "items": [
+					"unit_turret"
+				],
               "tagSetSourceFile": "tags/UnitTags"
             },
             "spawnEffectTags": {
@@ -1153,7 +1159,9 @@
               "tagSetSourceFile": "tags/UnitTags"
             },
             "unitExcludedTagSet": {
-              "items": [],
+              "items": [
+					"unit_turret"
+				],
               "tagSetSourceFile": "tags/UnitTags"
             },
             "spawnEffectTags": {


### PR DESCRIPTION
somehow has mechs spawned as turrets even if it has turrets selected...