### PR TITLE
Updated Intensify Firepower and Hull Down tooltips

### DIFF
--- a/Abilifier/abilities/AbilityDefG5T.json
+++ b/Abilifier/abilities/AbilityDefG5T.json
@@ -2,7 +2,7 @@
 	"Description": {
 		"Id": "AbilityDefG5T",
 		"Name": "INTENSIFY FIREPOWER",
-		"Details": "ACTION: Intentionally pillbox this tank, losing all ability to move for the following turn. In exchange, gain +30% damage this turn. 4 turn cooldown. <b><color=#099ff2>Costs 30 Resolve to use!</color></b>",
+		"Details": "ACTION: Cannot be used if you have moved this turn. Intentionally pillbox this tank, losing all ability to move this turn. In exchange, gain +30% damage this turn. 4 turn cooldown. <b><color=#099ff2>Costs 30 Resolve to use!</color></b>",
 		"Icon": "hypersonic-bolt"
 	},
 	"DisplayParams": "ShowInMWTRay",
@@ -30,7 +30,7 @@
 			"Description": {
 				"Id": "StatusEffect-IntenseCruise",
 				"Name": "Intensified Firepower",
-				"Details": "This unit can no longer move but deals +30% damage for this turn.",
+				"Details": "This unit can not move this turn but deals +30% damage for this turn.",
 				"Icon": "hypersonic-bolt"
 			},
 			"statisticData": {
@@ -58,7 +58,7 @@
 			"Description": {
 				"Id": "StatusEffect-IntenseFlank",
 				"Name": "Intensified Firepower",
-				"Details": "This unit can no longer move but deals +30% damage for this turn.",
+				"Details": "This unit can not move this turn but deals +30% damage for this turn.",
 				"Icon": "hypersonic-bolt"
 			},
 			"statisticData": {
@@ -85,7 +85,7 @@
 			"Description": {
 				"Id": "StatusEffect-IntenseDmgBoost",
 				"Name": "Intensified Firepower",
-				"Details": "This unit can no longer move but deals +30% damage for this turn.",
+				"Details": "This unit can not move this turn but deals +30% damage for this turn.",
 				"Icon": "hypersonic-bolt"
 			},
 			"statisticData": {

--- a/Abilifier/abilities/AbilityDefGu10T.json
+++ b/Abilifier/abilities/AbilityDefGu10T.json
@@ -2,7 +2,7 @@
 	"Description": {
 		"Id": "AbilityDefGu10T",
 		"Name": "HULL DOWN",
-		"Details": "ACTION: Intentionally pillbox this tank, losing all ability to move for 2 turns. In exchange, take 90% reduced damage from all sources for 2 turns. 4 turn cooldown. <b><color=#099ff2>Costs 30 Resolve to use!</color></b>",
+		"Details": "ACTION: Cannot be used if you have moved this turn. Intentionally pillbox this tank, losing all ability to move for this turn and the next turn. In exchange, take 90% reduced damage from all sources until the end of your next turn. 4 turn cooldown. <b><color=#099ff2>Costs 30 Resolve to use!</color></b>",
 		"Icon": "shield-reflect"
 	},
 	"DisplayParams": "ShowInMWTRay",
@@ -30,7 +30,7 @@
 			"Description": {
 				"Id": "StatusEffect-HullDownCruise",
 				"Name": "Hull Down",
-				"Details": "This unit can no longer move but takes 90% reduced damage from all sources for 2 turns.",
+				"Details": "This unit can not move this turn but takes 90% reduced damage from all sources until end of next turn.",
 				"Icon": "shield-reflect"
 			},
 			"statisticData": {
@@ -58,7 +58,7 @@
 			"Description": {
 				"Id": "StatusEffect-HullDownFlank",
 				"Name": "Hull Down",
-				"Details": "This unit can no longer move but takes 90% reduced damage from all sources for 2 turns.",
+				"Details": "This unit can not move this turn but takes 90% reduced damage from all sources until end of next turn.",
 				"Icon": "shield-reflect"
 			},
 			"statisticData": {
@@ -85,7 +85,7 @@
 			"Description": {
 				"Id": "StatusEffect-HullDownDmgReduce",
 				"Name": "Hull Down",
-				"Details": "This unit can no longer move but takes 90% reduced damage from all sources for 2 turns.",
+				"Details": "This unit can not move this turn but takes 90% reduced damage from all sources until end of next turn.",
 				"Icon": "shield-reflect"
 			},
 			"statisticData": {


### PR DESCRIPTION
Updated Intensify Firepower and Hull Down tooltips to be a bit more clear in how they work and that they cannot be used if you have already moved that turn.