### PR TITLE
Atlas ETP quirk fix and Patton armour

### DIFF
--- a/Community Content/upgrade/Gear_Quirk_EasytoPilot_Atlas.json
+++ b/Community Content/upgrade/Gear_Quirk_EasytoPilot_Atlas.json
@@ -97,31 +97,6 @@
 				"modType": "System.Single"
 			},
 			"nature": "Buff"
-		},
-		{
-			"durationData": {
-				"duration": -1,
-				"stackLimit": 1
-			},
-			"targetingData": {
-				"effectTriggerType": "Passive",
-				"effectTargetType": "Creator",
-				"showInStatusPanel": false
-			},
-			"effectType": "StatisticEffect",
-			"Description": {
-				"Id": "EtPSprint",
-				"Name": "ChargerSprint",
-				"Details": "Increased sprint speed.",
-				"Icon": "uixSvgIcon_run_n_gun"
-			},
-			"statisticData": {
-				"modValue": "0.1",
-                "operation": "Float_Add",
-                "statName": "CBTBE_RunMultiMod",
-				"modType": "System.Single"
-			},
-			"nature": "Buff"
 		}
 	],
 	"ComponentTags": {

--- a/VIPAdvanced/heavy/vehicledef_PATTON.json
+++ b/VIPAdvanced/heavy/vehicledef_PATTON.json
@@ -67,9 +67,9 @@
 		},
 		{
 			"Location": "Right",
-			"CurrentArmor": 260,
+			"CurrentArmor": 230,
 			"CurrentInternalStructure": 35,
-			"AssignedArmor": 260,
+			"AssignedArmor": 230,
 			"DamageLevel": "Functional"
 		},
 		{


### PR DESCRIPTION
Removed sprint speed boost to bring quirk into line with other ETP quirk settings. Adjusted Patton right side armour to match left side