### PR TITLE
HGN-IB added missing AP hardpoints

### DIFF
--- a/Community Content/chassis/chassisdef_highlander_HGN-IB.json
+++ b/Community Content/chassis/chassisdef_highlander_HGN-IB.json
@@ -129,6 +129,14 @@
 				{
 					"WeaponMount": "AntiPersonnel",
 					"Omni": false
+				},
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
+				},
+				{
+					"WeaponMount": "AntiPersonnel",
+					"Omni": false
 				}
 			],
 			"Tonnage": 0,


### PR DESCRIPTION
HGN-IB had three support weapons in right torso but only one support hardpoint. Added two more to validate the build.