### PR TITLE
Fix Apollo MRM Crit Chance

### DIFF
--- a/CustomAmmoCategories/ammunition/Ammunition_MRM_Apollo.json
+++ b/CustomAmmoCategories/ammunition/Ammunition_MRM_Apollo.json
@@ -13,7 +13,7 @@
 	"Category": "MRM",
 	"AIBattleValue": 90,
 	"AccuracyModifier": -1.0,
-	"CriticalChanceMultiplier": 1.2,
+	"CriticalChanceMultiplier": 0.2,
 	"HeatGenerated": 0,
 	"HeatGeneratedModifier": 1,
 	"ArmorDamageModifier": 1,

--- a/MechAffinity/settings.json
+++ b/MechAffinity/settings.json
@@ -1355,12 +1355,8 @@
 		{
 			"tag": "Affinity_tbone_Corsair",
 			"chassisNames": [
-				"chrprfmech_rtcorsair1base-001_75",
-				"chrprfmech_rtcorsair1base-001_95",
-				"chrprfmech_rtcorsair2base-001_95",
-				"chrprfmech_rtcorsair3base-001_95",
-				"chrprfmech_rtcorsair4base-001_95",
-				"chrprfmech_rtcorsair5base-001_95"
+				"Corsair_75",
+				"Corsair_95"
 			],
 			"affinityLevels": [
 				{


### PR DESCRIPTION
Two fixes:

Regarding Apollo MRM ammo: "CriticalChanceMultiplier" for ammo is added to the value for the weapon. Old value of 1.2 would make crit chance multiplier 2.2 would give it a boosted 120% crit chance, I believe. The corrected 0.2 should give it the intended 20% boost.

Regarding t-bone's Mech Affinity for Corsairs: It was set to apply to the PrefabIdentifiers for the corsairs but MechAffinity works off of the PrefabID under Custom. I changed it to apply to that ID instead with the tonnage and it works during testing.