### PR TITLE
Hussar/Hermes unit tag fix; Thumper/Sniper direct fire range fix

### DIFF
--- a/BT Advanced Gear/weapon/Weapon_Autocannon_SNIPER.json
+++ b/BT Advanced Gear/weapon/Weapon_Autocannon_SNIPER.json
@@ -88,7 +88,7 @@
 			"AccuracyModifier": 1.0,
 			"IndirectFireCapable": false,
 			"ShortRange": -120.0,
-			"MediumRange": -520.0,
+			"MediumRange": -460.0,
 			"LongRange": -790.0,
 			"MaxRange": -1020.0
 		},

--- a/BT Advanced Gear/weapon/Weapon_Autocannon_THUMPER.json
+++ b/BT Advanced Gear/weapon/Weapon_Autocannon_THUMPER.json
@@ -87,7 +87,7 @@
 			"AccuracyModifier": 1.0,
 			"IndirectFireCapable": false,
 			"ShortRange": -120.0,
-			"MediumRange": -520.0,
+			"MediumRange": -460.0,
 			"LongRange": -790.0,
 			"MaxRange": -1020.0
 		},

--- a/BT Advanced Mechs/mech/mechdef_hermes_HER-1A.json
+++ b/BT Advanced Mechs/mech/mechdef_hermes_HER-1A.json
@@ -2,7 +2,7 @@
 	"MechTags": {
 		"items": [
 			"unit_mech",
-			"unit_medium",
+			"unit_light",
 			"unit_lance_vanguard",
 			"unit_role_scout",
 			"unit_release",

--- a/BT Advanced Mechs/mech/mechdef_hermes_HER-1B.json
+++ b/BT Advanced Mechs/mech/mechdef_hermes_HER-1B.json
@@ -2,7 +2,7 @@
 	"MechTags": {
 		"items": [
 			"unit_mech",
-			"unit_medium",
+			"unit_light",
 			"unit_lance_vanguard",
 			"unit_role_scout",
 			"unit_release",

--- a/BT Advanced Mechs/mech/mechdef_hermes_HER-1S.json
+++ b/BT Advanced Mechs/mech/mechdef_hermes_HER-1S.json
@@ -2,7 +2,7 @@
 	"MechTags": {
 		"items": [
 			"unit_mech",
-			"unit_medium",
+			"unit_light",
 			"unit_lance_vanguard",
 			"unit_role_scout",
 			"unit_release",

--- a/BT Advanced Mechs/mech/mechdef_hermes_HER-1Sb.json
+++ b/BT Advanced Mechs/mech/mechdef_hermes_HER-1Sb.json
@@ -2,7 +2,7 @@
 	"MechTags": {
 		"items": [
 			"unit_mech",
-			"unit_medium",
+			"unit_light",
 			"unit_lance_vanguard",
 			"unit_role_scout",
 			"unit_release",

--- a/BT Advanced Mechs/mech/mechdef_hermes_HER-3S.json
+++ b/BT Advanced Mechs/mech/mechdef_hermes_HER-3S.json
@@ -2,7 +2,7 @@
 	"MechTags": {
 		"items": [
 			"unit_mech",
-			"unit_medium",
+			"unit_light",
 			"unit_lance_vanguard",
 			"unit_role_scout",
 			"unit_release",

--- a/BT Advanced Mechs/mech/mechdef_hermes_HER-3S1.json
+++ b/BT Advanced Mechs/mech/mechdef_hermes_HER-3S1.json
@@ -2,7 +2,7 @@
 	"MechTags": {
 		"items": [
 			"unit_mech",
-			"unit_medium",
+			"unit_light",
 			"unit_lance_vanguard",
 			"unit_role_scout",
 			"unit_release",

--- a/BT Advanced Mechs/mech/mechdef_hermes_HER-3S2.json
+++ b/BT Advanced Mechs/mech/mechdef_hermes_HER-3S2.json
@@ -2,7 +2,7 @@
 	"MechTags": {
 		"items": [
 			"unit_mech",
-			"unit_medium",
+			"unit_light",
 			"unit_lance_vanguard",
 			"unit_role_scout",
 			"unit_release",

--- a/BT Advanced Mechs/mech/mechdef_hermes_HER-4M.json
+++ b/BT Advanced Mechs/mech/mechdef_hermes_HER-4M.json
@@ -2,7 +2,7 @@
 	"MechTags": {
 		"items": [
 			"unit_mech",
-			"unit_medium",
+			"unit_light",
 			"unit_lance_vanguard",
 			"unit_role_scout",
 			"unit_release",

--- a/BT Advanced Mechs/mech/mechdef_hermes_HER-4S.json
+++ b/BT Advanced Mechs/mech/mechdef_hermes_HER-4S.json
@@ -2,7 +2,7 @@
 	"MechTags": {
 		"items": [
 			"unit_mech",
-			"unit_medium",
+			"unit_light",
 			"unit_lance_vanguard",
 			"unit_role_scout",
 			"unit_release",

--- a/BT Advanced Mechs/mech/mechdef_hussar_HSR-200-Db.json
+++ b/BT Advanced Mechs/mech/mechdef_hussar_HSR-200-Db.json
@@ -2,7 +2,7 @@
 	"MechTags": {
 		"items": [
 			"unit_mech",
-			"unit_medium",
+			"unit_light",
 			"unit_lance_vanguard",
 			"unit_role_scout",
 			"unit_release",

--- a/BT Advanced Mechs/mech/mechdef_hussar_HSR-300-D.json
+++ b/BT Advanced Mechs/mech/mechdef_hussar_HSR-300-D.json
@@ -2,7 +2,7 @@
 	"MechTags": {
 		"items": [
 			"unit_mech",
-			"unit_medium",
+			"unit_light",
 			"unit_lance_vanguard",
 			"unit_role_scout",
 			"unit_release",

--- a/BT Advanced Mechs/mech/mechdef_hussar_HSR-350-D.json
+++ b/BT Advanced Mechs/mech/mechdef_hussar_HSR-350-D.json
@@ -2,7 +2,7 @@
 	"MechTags": {
 		"items": [
 			"unit_mech",
-			"unit_medium",
+			"unit_light",
 			"unit_lance_vanguard",
 			"unit_role_scout",
 			"unit_release",

--- a/BT Advanced Mechs/mech/mechdef_hussar_HSR-400-D.json
+++ b/BT Advanced Mechs/mech/mechdef_hussar_HSR-400-D.json
@@ -2,7 +2,7 @@
 	"MechTags": {
 		"items": [
 			"unit_mech",
-			"unit_medium",
+			"unit_light",
 			"unit_lance_vanguard",
 			"unit_role_scout",
 			"unit_release",

--- a/BT Advanced Mechs/mech/mechdef_hussar_HSR-500-D.json
+++ b/BT Advanced Mechs/mech/mechdef_hussar_HSR-500-D.json
@@ -2,7 +2,7 @@
 	"MechTags": {
 		"items": [
 			"unit_mech",
-			"unit_medium",
+			"unit_light",
 			"unit_lance_vanguard",
 			"unit_role_scout",
 			"unit_release",


### PR DESCRIPTION
Hussar and Hermes change from unit_medium to unit_light.

Thumper and Sniper arty range brackets for direct fire were 120/240/200/290/420. Fix changes that to 120/240/260/290/420.
