### PR TITLE
JarnFolk repme fix

### DIFF
--- a/VIPAdvanced/convoy/vehicledef_Burro.json
+++ b/VIPAdvanced/convoy/vehicledef_Burro.json
@@ -33,6 +33,7 @@
 			"Rasalhague",
 			"Ives",
 			"Marian",
+			"JarnFolk",
 			"Hanse",
 			"Rim",
 			"Outworld",

--- a/VIPAdvanced/convoy/vehicledef_Burro_Cistern.json
+++ b/VIPAdvanced/convoy/vehicledef_Burro_Cistern.json
@@ -33,6 +33,7 @@
 			"Rasalhague",
 			"Ives",
 			"Marian",
+			"JarnFolk",
 			"Hanse",
 			"Rim",
 			"Outworld",

--- a/VIPAdvanced/convoy/vehicledef_Burro_Flatbed.json
+++ b/VIPAdvanced/convoy/vehicledef_Burro_Flatbed.json
@@ -33,6 +33,7 @@
 			"Rasalhague",
 			"Ives",
 			"Marian",
+			"JarnFolk",
 			"Hanse",
 			"Rim",
 			"Outworld",

--- a/VIPAdvanced/convoy/vehicledef_Burro_Q.json
+++ b/VIPAdvanced/convoy/vehicledef_Burro_Q.json
@@ -33,6 +33,7 @@
 			"Rasalhague",
 			"Ives",
 			"Marian",
+			"JarnFolk",
 			"Hanse",
 			"Rim",
 			"Outworld",

--- a/VIPAdvanced/convoy/vehicledef_Burro_Support.json
+++ b/VIPAdvanced/convoy/vehicledef_Burro_Support.json
@@ -33,6 +33,7 @@
 			"Rasalhague",
 			"Ives",
 			"Marian",
+			"JarnFolk",
 			"Hanse",
 			"Rim",
 			"Outworld",

--- a/VIPAdvanced/convoy/vehicledef_J-27.json
+++ b/VIPAdvanced/convoy/vehicledef_J-27.json
@@ -33,6 +33,7 @@
 			"Rasalhague",
 			"Ives",
 			"Marian",
+			"JarnFolk",
 			"Hanse",
 			"Rim",
 			"Outworld",

--- a/VIPAdvanced/convoy/vehicledef_J-27_ARMOR.json
+++ b/VIPAdvanced/convoy/vehicledef_J-27_ARMOR.json
@@ -33,6 +33,7 @@
 			"Rasalhague",
 			"Ives",
 			"Marian",
+			"JarnFolk",
 			"Hanse",
 			"Rim",
 			"Outworld",

--- a/VIPAdvanced/convoy/vehicledef_J-27_FUSION.json
+++ b/VIPAdvanced/convoy/vehicledef_J-27_FUSION.json
@@ -33,6 +33,7 @@
 			"Rasalhague",
 			"Ives",
 			"Marian",
+			"JarnFolk",
 			"Hanse",
 			"Rim",
 			"Outworld",

--- a/VIPAdvanced/convoy/vehicledef_J37.json
+++ b/VIPAdvanced/convoy/vehicledef_J37.json
@@ -33,6 +33,7 @@
 			"Rasalhague",
 			"Ives",
 			"Marian",
+			"JarnFolk",
 			"Hanse",
 			"Rim",
 			"Outworld",

--- a/VIPAdvanced/convoy/vehicledef_J37_Cistern.json
+++ b/VIPAdvanced/convoy/vehicledef_J37_Cistern.json
@@ -33,6 +33,7 @@
 			"Rasalhague",
 			"Ives",
 			"Marian",
+			"JarnFolk",
 			"Hanse",
 			"Rim",
 			"Outworld",

--- a/VIPAdvanced/convoy/vehicledef_J37_Q.json
+++ b/VIPAdvanced/convoy/vehicledef_J37_Q.json
@@ -33,6 +33,7 @@
 			"Rasalhague",
 			"Ives",
 			"Marian",
+			"JarnFolk",
 			"Hanse",
 			"Rim",
 			"Outworld",

--- a/VIPAdvanced/convoy/vehicledef_J37_Support.json
+++ b/VIPAdvanced/convoy/vehicledef_J37_Support.json
@@ -33,6 +33,7 @@
 			"Rasalhague",
 			"Ives",
 			"Marian",
+			"JarnFolk",
 			"Hanse",
 			"Rim",
 			"Outworld",

--- a/VIPAdvanced/convoy/vehicledef_K-27.json
+++ b/VIPAdvanced/convoy/vehicledef_K-27.json
@@ -33,6 +33,7 @@
 			"Rasalhague",
 			"Ives",
 			"Marian",
+			"JarnFolk",
 			"Hanse",
 			"Rim",
 			"Outworld",

--- a/VIPAdvanced/convoy/vehicledef_MASHTruck.json
+++ b/VIPAdvanced/convoy/vehicledef_MASHTruck.json
@@ -31,6 +31,7 @@
 			"MagistracyOfCanopus",
 			"TaurianConcordat",
 			"Marian",
+			"JarnFolk",
 			"Hanse",
 			"Rim",
 			"Outworld",


### PR DESCRIPTION
added JarnFolk to convoy trucks, they had none

Please reach out to the team via discord (https://discord.com/invite/g5nCYAV) before opening a PR. We appreciate community input, but prefer to get to know you first.
