### PR TITLE
Fixed Jenner Oxide engine

### DIFF
--- a/BT Advanced Unique Mechs/mech/mechdef_jenner_JR7-O.json
+++ b/BT Advanced Unique Mechs/mech/mechdef_jenner_JR7-O.json
@@ -160,6 +160,17 @@
 		},
 		{
 			"MountedLocation": "CenterTorso",
+			"ComponentDefID": "emod_engineslots_std_center",
+			"SimGameUID": null,
+			"ComponentDefType": "HeatSink",
+			"HardpointSlot": -1,
+			"GUID": null,
+			"DamageLevel": "Functional",
+			"prefabName": null,
+			"hasPrefabName": false
+		},
+		{
+			"MountedLocation": "CenterTorso",
 			"ComponentDefID": "Gear_Gyro_Generic_Standard",
 			"SimGameUID": null,
 			"ComponentDefType": "Upgrade",


### PR DESCRIPTION
Was missing a line for the standard engine which was borking the wiki tool
