### PR TITLE
MAD-BH2 lower arm actuator; RFL quirk typo fix

### DIFF
--- a/BT Advanced Mech Quirks/upgrade/Gear_Quirk_ImprovedCommunications_Rifleman.json
+++ b/BT Advanced Mech Quirks/upgrade/Gear_Quirk_ImprovedCommunications_Rifleman.json
@@ -72,7 +72,7 @@
 			"Description": {
 				"Id": "ImprovedCommunications",
 				"Name": "Improved Communications",
-				"Details": "Provides a +2 bonus to actions that generate Morale.",
+				"Details": "Provides a +3 bonus to actions that generate Morale.",
 				"Icon": "uixSvgIcon_equipment_Cockpit"
 			},
 			"nature": "Buff",

--- a/BT Advanced Unique Mechs/mech/mechdef_marauder_MAD-BH2.json
+++ b/BT Advanced Unique Mechs/mech/mechdef_marauder_MAD-BH2.json
@@ -343,6 +343,17 @@
 			"hasPrefabName": false
 		},
 		{
+			"MountedLocation": "RightArm",
+			"ComponentDefID": "emod_arm_part_lower",
+			"SimGameUID": "",
+			"ComponentDefType": "Upgrade",
+			"HardpointSlot": 0,
+			"GUID": null,
+			"DamageLevel": "Functional",
+			"prefabName": null,
+			"hasPrefabName": false
+		},
+		{
 			"MountedLocation": "Head",
 			"ComponentDefID": "Weapon_Laser_MediumLaser_0-STOCK",
 			"SimGameUID": null,
@@ -431,6 +442,17 @@
 			"hasPrefabName": false
 		},
 		{
+			"MountedLocation": "CenterTorso",
+			"ComponentDefID": "Ammo_AmmunitionBox_Generic_GAUSS",
+			"SimGameUID": null,
+			"ComponentDefType": "AmmunitionBox",
+			"HardpointSlot": -1,
+			"GUID": null,
+			"DamageLevel": "Functional",
+			"prefabName": null,
+			"hasPrefabName": false
+		},
+		{
 			"MountedLocation": "RightTorso",
 			"ComponentDefID": "Weapon_Gauss_Gauss_0-STOCK",
 			"SimGameUID": null,
@@ -454,9 +476,9 @@
 		},
 		{
 			"MountedLocation": "RightTorso",
-			"ComponentDefID": "Ammo_AmmunitionBox_Generic_GAUSS",
+			"ComponentDefID": "Gear_HeatSink_Generic_Double",
 			"SimGameUID": null,
-			"ComponentDefType": "AmmunitionBox",
+			"ComponentDefType": "HeatSink",
 			"HardpointSlot": -1,
 			"GUID": null,
 			"DamageLevel": "Functional",
@@ -480,17 +502,6 @@
 			"SimGameUID": null,
 			"ComponentDefType": "Weapon",
 			"HardpointSlot": 1,
-			"GUID": null,
-			"DamageLevel": "Functional",
-			"prefabName": null,
-			"hasPrefabName": false
-		},
-		{
-			"MountedLocation": "RightArm",
-			"ComponentDefID": "Gear_HeatSink_Generic_Double",
-			"SimGameUID": null,
-			"ComponentDefType": "HeatSink",
-			"HardpointSlot": -1,
 			"GUID": null,
 			"DamageLevel": "Functional",
 			"prefabName": null,

--- a/BT Advanced Unique Mechs/upgrade/Gear_Quirk_NotonsSpirit_Rifleman-LK.json
+++ b/BT Advanced Unique Mechs/upgrade/Gear_Quirk_NotonsSpirit_Rifleman-LK.json
@@ -157,7 +157,7 @@
 			"Description": {
 				"Id": "NotonsSpirit-EnergyAccuracy",
 				"Name": "Energy Accuracy Increased",
-				"Details": "Energy attacks gain +2 accuracy.",
+				"Details": "Energy attacks gain +3 accuracy.",
 				"Icon": "plasma-bolt"
 			},
 			"nature": "Buff",
@@ -248,7 +248,7 @@
 			"Description": {
 				"Id": "NotonsSpirit-Initiative",
 				"Name": "Command Consoles",
-				"Details": "Provides + 1 Initiative and several buffs.",
+				"Details": "Provides +2 Initiative and several buffs.",
 				"Icon": "uixSvgIcon_equipment_Cockpit"
 			},
 			"nature": "Buff",


### PR DESCRIPTION
Shuffled some gear on the MAD-BH2 so it can have both lower arm actuators and a minor typo fix for Rifleman and RFL-LK quirks.