### PR TITLE
Proper quotation marks for the HEP-BM's stock role

### DIFF
--- a/BT Advanced Unique Mechs/chassis/chassisdef_helepolis_HEP-BM.json
+++ b/BT Advanced Unique Mechs/chassis/chassisdef_helepolis_HEP-BM.json
@@ -214,7 +214,7 @@
 		],
 		"tagSetSourceFile": ""
 	},
-	"StockRole": "''Artillery''",
+	"StockRole": "\"Artillery\"",
 	"YangsThoughts": "Named for the graffiti found on the side of the barrel of its primary weapon, ''Boomstick'' as it came to be called is a monstrous gladiator mech capable of extreme damage against unsuspecting opponents. When a Helepolis walks into the arena, opponents laugh and dismiss it, only for the Sniper Artillery Cannon to blow limbs asunder as the Boomstick rampages forward. The Clan-spec ER PPC and IS-spec Snub-Nose PPC provide that extra sting of insult to injury as Boomstick stands over its defeated foes.",
 	"FixedEquipment": [
 		{


### PR DESCRIPTION
Escaped the quotes because the original version of double apostrophes was having some unintended side-effects on the wiki
