### PR TITLE
Mortar FASCAM (half) fix

### DIFF
--- a/CustomAmmoCategories/Mortar/Ammo_AmmunitionBox_Fascam_Mortar_half.json
+++ b/CustomAmmoCategories/Mortar/Ammo_AmmunitionBox_Fascam_Mortar_half.json
@@ -16,11 +16,17 @@
 		},
 		"BonusDescriptions": {
 			"Bonuses": [
-				"ThunderMines: 3",
-				"ThunderRadius: 5",
-				"ThunderChance: 20%",
-				"ThunderDamage: 4",
 				"Thunder",
+				"ThunderCripple",
+				"ThunderMines: 1",
+				"ThunderChance: 80%",
+				"ThunderDamage: 5",
+				"ThunderHeatDamage: 5",
+				"ThunderAOERadius: 30",
+				"ThunderAOEDamage: 5",
+				"ThunderAOEHeatDamage: 5",
+				"ThunderAOEStabDamage: 1",
+				"DamageMod: -50%",
 				"CostPerShot: 200",
 				"MortarAmmo: 20"
 			]


### PR DESCRIPTION
Replaced the existing bonuses with the ones from the full ammo bin which I assume is the more correct version, with adjusted ammo count for the half bin value