### PR TITLE
gameworld duels fix

### DIFF
--- a/MissionControl/overrides/contracts/duoduel/DuoDuel_GameworldDuoAssault.json
+++ b/MissionControl/overrides/contracts/duoduel/DuoDuel_GameworldDuoAssault.json
@@ -422,9 +422,7 @@
 					"tagSetSourceFile": "tags/LanceTags"
 				},
 				"lanceExcludedTagSet": {
-					"items": [
-						"lance_type_turret"
-					],
+					"items": [],
 					"tagSetSourceFile": "tags/LanceTags"
 				},
 				"spawnEffectTags": {

--- a/MissionControl/overrides/contracts/duoduel/DuoDuel_GameworldDuoHeavy.json
+++ b/MissionControl/overrides/contracts/duoduel/DuoDuel_GameworldDuoHeavy.json
@@ -454,9 +454,7 @@
 					"tagSetSourceFile": "tags/LanceTags"
 				},
 				"lanceExcludedTagSet": {
-					"items": [
-						"lance_type_turret"
-					],
+					"items": [],
 					"tagSetSourceFile": "tags/LanceTags"
 				},
 				"spawnEffectTags": {

--- a/MissionControl/overrides/contracts/duoduel/DuoDuel_GameworldDuoLight.json
+++ b/MissionControl/overrides/contracts/duoduel/DuoDuel_GameworldDuoLight.json
@@ -454,9 +454,7 @@
 					"tagSetSourceFile": "tags/LanceTags"
 				},
 				"lanceExcludedTagSet": {
-					"items": [
-						"lance_type_turret"
-					],
+					"items": [],
 					"tagSetSourceFile": "tags/LanceTags"
 				},
 				"spawnEffectTags": {

--- a/MissionControl/overrides/contracts/duoduel/DuoDuel_GameworldDuoMedium.json
+++ b/MissionControl/overrides/contracts/duoduel/DuoDuel_GameworldDuoMedium.json
@@ -422,9 +422,7 @@
 					"tagSetSourceFile": "tags/LanceTags"
 				},
 				"lanceExcludedTagSet": {
-					"items": [
-						"lance_type_turret"
-					],
+					"items": [],
 					"tagSetSourceFile": "tags/LanceTags"
 				},
 				"spawnEffectTags": {

--- a/MissionControl/overrides/contracts/soloduel/SoloDuel_GameworldSoloAssault.json
+++ b/MissionControl/overrides/contracts/soloduel/SoloDuel_GameworldSoloAssault.json
@@ -380,9 +380,7 @@
 					"tagSetSourceFile": "tags/LanceTags"
 				},
 				"lanceExcludedTagSet": {
-					"items": [
-						"lance_type_turret"
-					],
+					"items": [],
 					"tagSetSourceFile": "tags/LanceTags"
 				},
 				"spawnEffectTags": {

--- a/MissionControl/overrides/contracts/soloduel/SoloDuel_GameworldSoloHeavy.json
+++ b/MissionControl/overrides/contracts/soloduel/SoloDuel_GameworldSoloHeavy.json
@@ -405,9 +405,7 @@
 					"tagSetSourceFile": "tags/LanceTags"
 				},
 				"lanceExcludedTagSet": {
-					"items": [
-						"lance_type_turret"
-					],
+					"items": [],
 					"tagSetSourceFile": "tags/LanceTags"
 				},
 				"spawnEffectTags": {

--- a/MissionControl/overrides/contracts/soloduel/SoloDuel_GameworldSoloLight.json
+++ b/MissionControl/overrides/contracts/soloduel/SoloDuel_GameworldSoloLight.json
@@ -405,9 +405,7 @@
 					"tagSetSourceFile": "tags/LanceTags"
 				},
 				"lanceExcludedTagSet": {
-					"items": [
-						"lance_type_turret"
-					],
+					"items": [],
 					"tagSetSourceFile": "tags/LanceTags"
 				},
 				"spawnEffectTags": {

--- a/MissionControl/overrides/contracts/soloduel/SoloDuel_GameworldSoloMedium.json
+++ b/MissionControl/overrides/contracts/soloduel/SoloDuel_GameworldSoloMedium.json
@@ -380,9 +380,7 @@
 					"tagSetSourceFile": "tags/LanceTags"
 				},
 				"lanceExcludedTagSet": {
-					"items": [
-						"lance_type_turret"
-					],
+					"items": [],
 					"tagSetSourceFile": "tags/LanceTags"
 				},
 				"spawnEffectTags": {


### PR DESCRIPTION
drop turret exclusion so the correct gladiator lances get pulled

Please reach out to the team via discord (https://discord.com/invite/g5nCYAV) before opening a PR. We appreciate community input, but prefer to get to know you first.
