### PR TITLE
Incendiary MG/Gyro Equilibrium tweaks

### DIFF
--- a/BT Advanced Weapon Rebalance/weapons/Weapon_MachineGun_MachineGun_1-Brigadier.json
+++ b/BT Advanced Weapon Rebalance/weapons/Weapon_MachineGun_MachineGun_1-Brigadier.json
@@ -79,7 +79,6 @@
 			"isBaseMode": false,
 			"ShotsWhenFired": 1,
 			"HeatGenerated": 3,
-			"RefireModifier": 1,
 			"FlatJammingChance": 0.15,
 			"CriticalChanceMultiplier": -0.25
 		},
@@ -89,7 +88,6 @@
 			"isBaseMode": false,
 			"ShotsWhenFired": 2,
 			"HeatGenerated": 6,
-			"RefireModifier": 2,
 			"FlatJammingChance": 0.3,
 			"CriticalChanceMultiplier": -0.5
 		}

--- a/MechengineerGear/data/vanilla/gyro/Gear_Gyro_Hermes_Equilibrium.json
+++ b/MechengineerGear/data/vanilla/gyro/Gear_Gyro_Hermes_Equilibrium.json
@@ -25,7 +25,7 @@
     "RelativeModifier" : 0,
     "AbsoluteModifier" : 0,
     "Description" : {
-        "Cost" : 3000000,
+        "Cost" : 300000,
         "Rarity" : 99,
         "Purchasable" : true,
         "Manufacturer" : "Hermes",


### PR DESCRIPTION
Incendiary MGs got missed in the balance pass. Reduced Gyro cost to bring it in line with other stability gyros since it was drastically higher priced at 3 million