### PR TITLE
Fix Employer and Contract IDs

### DIFF
--- a/InnerSphereMap/StarSystems/starsystemdef_Jardine(Herakleion2822+).json
+++ b/InnerSphereMap/StarSystems/starsystemdef_Jardine(Herakleion2822+).json
@@ -150,9 +150,15 @@
 	"DifficultyList": [],
 	"DifficultyModes": [],
 	"contractEmployerIDs": [
-		"WordOfBlake"
+		"WordOfBlake",
+		"Locals"
 	],
 	"contractTargetIDs": [
-		"AuriganPirates"
+		"Steiner",
+		"Davion",
+		"Liao",
+		"Kurita",
+		"ComStar",
+		"Rasalhague"
 	]
 }


### PR DESCRIPTION
I made a ticket for this on Monday but didn't really have time to follow it up during the week so it got closed. Jardine doesn't seem to ever offer contracts. I have more logs to prove it, or you can just try in-game. I gave it multiple months and a brand new campaign, but the system just does not spawn contracts, despite not having the typical tags that would indicate such to players. 

I used values from Gibson to fill this out.

Changes have been tested, but I assume you all have your own process. 