### PR TITLE
overlord icon error fix

### DIFF
--- a/MonsterMashup/vehiclechassis/vehiclechassisdef_OVERLORD_DROPSHIP.json
+++ b/MonsterMashup/vehiclechassis/vehiclechassisdef_OVERLORD_DROPSHIP.json
@@ -3,7 +3,7 @@
     "Id": "vehiclechassisdef_OVERLORD_DROPSHIP",
     "Name": "Overlord Dropship",
     "Details": "",
-    "Icon": "STRIKER",
+    "Icon": "Striker",
     "Cost": 564,
     "Rarity": 0,
     "Purchasable": false


### PR DESCRIPTION
changed icon case to make the error go away

Please reach out to the team via discord (https://discord.com/invite/g5nCYAV) before opening a PR. We appreciate community input, but prefer to get to know you first.
