### PR TITLE
TTS Bonus Descriptions and Cyclops Descriptions

### DIFF
--- a/BT Advanced Core/settings/bonusDescriptions/BonusDescriptions_MechEngineer.json
+++ b/BT Advanced Core/settings/bonusDescriptions/BonusDescriptions_MechEngineer.json
@@ -2772,6 +2772,12 @@
 			"Full": "{0} Initiative"
 		},
 		{
+			"Bonus": "TargetInitiative",
+			"Short": "{0} Ini",
+			"Long": "{0} Target Initiative",
+			"Full": "This equipment reduces the target's initiative by {0}."
+		},
+		{
 			"Bonus": "Crits",
 			"Short": "{0} Crit",
 			"Long": "{0} Criticals",
@@ -4219,8 +4225,8 @@
 		},
 		{
 			"Bonus": "ICESpeed",
-			"Short": "Internal Combusion Engine Movement Penalty",
-			"Long": "Internal Combusion Engine Movement Penalty",
+			"Short": "Internal Combustion Engine Movement Penalty",
+			"Long": "Internal Combustion Engine Movement Penalty",
 			"Full": "Internal combustion engines are weak and slow, equating to a {0} movement penalty."
 		},
 		{
@@ -4554,6 +4560,18 @@
 			"Full": "3rd Generation Missile Launcher Ammo - {0} Shots"
 		},
 		{
+			"Bonus": "HPG",
+			"Short": "Ground Mobile HPG",
+			"Long": "Ground Mobile Hyperpulse Generator",
+			"Full": "This is a Ground Mobile Hyperpulse Generator, a miniturized version of the basis of all interstellar communication technology. The Ground Mobile HPG is capable of emitting a pulse that forces mechs into shutdown automatically, though it is slow to charge."
+		},
+		{
+			"Bonus": "HPGStrength",
+			"Short": "HPG Shutdown",
+			"Long": "HPG Shutdown Chance",
+			"Full": "The Ground Mobile HPG has a base chance to shut down its target of {0}, modified by the target's Guts skill."
+		},
+		{
 			"Bonus": "Taser",
 			"Short": "Mech Taser",
 			"Long": "Mech Taser Effects",
@@ -4576,6 +4594,42 @@
 			"Short": "Taser Accuracy",
 			"Long": "Taser Accuracy Debuff",
 			"Full": "The Mech Taser scrambles the target's systems, reducing accuracy by {0}."
+		},
+		{
+			"Bonus": "ArmorAmmo",
+			"Short": "Armor Repair",
+			"Long": "Armor Repair Functionality",
+			"Full": "This component is a bin of armor repair components used for in-field armor repair. This component repairs armor at a rate of 1 point of armor for 1 point from the bin. It cannot repair armor on destroyed or missing locations and it can only repair armor up to {0} of the original total."
+		},
+		{
+			"Bonus": "ArmorAmmoCount",
+			"Short": "Armor Repair",
+			"Long": "Armor Repair Components",
+			"Full": "Armor Repair Components - {0} total armor points."
+		},
+		{
+			"Bonus": "SPAMMYAmmo",
+			"Short": "SPAMMY",
+			"Long": "SPAce Magic Modular by Yang",
+			"Full": "This component is a bin of SPAce Magic Modular by Yang. It permits the refilling of any ammunition using SPAMMY points. It uses SPAMMY points equal to the equivalent tonnage-per-shot of the ammo it is replacing (for example: an AC/20 round is 1/5th of an ammo bin so it costs 1/5th of the SPAMMY points in the SPAMMY bin to refill 1 AC/20 round)."
+		},
+		{
+			"Bonus": "SPAMMYAmmoCount",
+			"Short": "SPAMMY Ammo",
+			"Long": "SPAMMY Ammo Count",
+			"Full": "SPAMMY Ammunition - {0} total SPAMMY points"
+		},
+		{
+			"Bonus": "NotUsed",
+			"Short": "Not Used",
+			"Long": "Not Used",
+			"Full": "This piece of gear is not used for any useful purpose in combat."
+		},
+		{
+			"Bonus": "AntiMissileDefense",
+			"Short": "{0} Anti-Missile Defense",
+			"Long": "{0} Anti-Missile Defense",
+			"Full": "{0} Defense against being hit by missile weapons"
 		}
 	]
 }

--- a/BT Advanced Core/settings/bonusDescriptions/BonusDescriptions_MechEngineer.json
+++ b/BT Advanced Core/settings/bonusDescriptions/BonusDescriptions_MechEngineer.json
@@ -2772,12 +2772,6 @@
 			"Full": "{0} Initiative"
 		},
 		{
-			"Bonus": "TargetInitiative",
-			"Short": "{0} Ini",
-			"Long": "{0} Target Initiative",
-			"Full": "This equipment reduces the target's initiative by {0}."
-		},
-		{
 			"Bonus": "Crits",
 			"Short": "{0} Crit",
 			"Long": "{0} Criticals",
@@ -4188,6 +4182,24 @@
 			"Full": "Provides {0} Evasion pips ignored"
 		},
 		{
+			"Bonus": "BallisticEvasionIgnore",
+			"Short": "{0} Ev.Evasion",
+			"Long": "{0} Ballistic Evasion Ignore",
+			"Full": "{0} Evasion Ignored with Ballistic weapons"
+		},
+		{
+			"Bonus": "EnergyEvasionIgnore",
+			"Short": "{0} Ev.Evasion",
+			"Long": "{0} Energy Evasion Ignore",
+			"Full": "{0} Evasion Ignored with Energy weapons"
+		},
+		{
+			"Bonus": "MissileEvasionIgnore",
+			"Short": "{0} Ev.Evasion",
+			"Long": "{0} Missile Evasion Ignore",
+			"Full": "{0} Evasion Ignored with Missile weapons"
+		},
+		{
 			"Bonus": "Clustering",
 			"Short": "Clustering Modifier of {0}",
 			"Long": "Clustering Modifier of {0}",
@@ -4207,8 +4219,8 @@
 		},
 		{
 			"Bonus": "ICESpeed",
-			"Short": "Internal Combustion Engine Movement Penalty",
-			"Long": "Internal Combustion Engine Movement Penalty",
+			"Short": "Internal Combusion Engine Movement Penalty",
+			"Long": "Internal Combusion Engine Movement Penalty",
 			"Full": "Internal combustion engines are weak and slow, equating to a {0} movement penalty."
 		},
 		{
@@ -4542,18 +4554,6 @@
 			"Full": "3rd Generation Missile Launcher Ammo - {0} Shots"
 		},
 		{
-			"Bonus": "HPG",
-			"Short": "Ground Mobile HPG",
-			"Long": "Ground Mobile Hyperpulse Generator",
-			"Full": "This is a Ground Mobile Hyperpulse Generator, a miniturized version of the basis of all interstellar communication technology. The Ground Mobile HPG is capable of emitting a pulse that forces mechs into shutdown automatically, though it is slow to charge."
-		},
-		{
-			"Bonus": "HPGStrength",
-			"Short": "HPG Shutdown",
-			"Long": "HPG Shutdown Chance",
-			"Full": "The Ground Mobile HPG has a base chance to shut down its target of {0}, modified by the target's Guts skill."
-		},
-		{
 			"Bonus": "Taser",
 			"Short": "Mech Taser",
 			"Long": "Mech Taser Effects",
@@ -4576,42 +4576,6 @@
 			"Short": "Taser Accuracy",
 			"Long": "Taser Accuracy Debuff",
 			"Full": "The Mech Taser scrambles the target's systems, reducing accuracy by {0}."
-		},
-		{
-			"Bonus": "ArmorAmmo",
-			"Short": "Armor Repair",
-			"Long": "Armor Repair Functionality",
-			"Full": "This component is a bin of armor repair components used for in-field armor repair. This component repairs armor at a rate of 1 point of armor for 1 point from the bin. It cannot repair armor on destroyed or missing locations and it can only repair armor up to {0} of the original total."
-		},
-		{
-			"Bonus": "ArmorAmmoCount",
-			"Short": "Armor Repair",
-			"Long": "Armor Repair Components",
-			"Full": "Armor Repair Components - {0} total armor points."
-		},
-		{
-			"Bonus": "SPAMMYAmmo",
-			"Short": "SPAMMY",
-			"Long": "SPAce Magic Modular by Yang",
-			"Full": "This component is a bin of SPAce Magic Modular by Yang. It permits the refilling of any ammunition using SPAMMY points. It uses SPAMMY points equal to the equivalent tonnage-per-shot of the ammo it is replacing (for example: an AC/20 round is 1/5th of an ammo bin so it costs 1/5th of the SPAMMY points in the SPAMMY bin to refill 1 AC/20 round)."
-		},
-		{
-			"Bonus": "SPAMMYAmmoCount",
-			"Short": "SPAMMY Ammo",
-			"Long": "SPAMMY Ammo Count",
-			"Full": "SPAMMY Ammunition - {0} total SPAMMY points"
-		},
-		{
-			"Bonus": "NotUsed",
-			"Short": "Not Used",
-			"Long": "Not Used",
-			"Full": "This piece of gear is not used for any useful purpose in combat."
-		},
-		{
-			"Bonus": "AntiMissileDefense",
-			"Short": "{0} Anti-Missile Defense",
-			"Long": "{0} Anti-Missile Defense",
-			"Full": "{0} Defense against being hit by missile weapons"
 		}
 	]
 }

--- a/Flashpoint Unit Module/chassis/chassisdef_cyclops_CP-10-Z-DC.json
+++ b/Flashpoint Unit Module/chassis/chassisdef_cyclops_CP-10-Z-DC.json
@@ -8,7 +8,7 @@
 		"UIName": "Cyclops",
 		"Id": "chassisdef_cyclops_CP-10-Z-DC",
 		"Name": "Cyclops",
-		"Details": "The preferred command 'Mech of the Capellan Confederation, the CP-10-Z-DC equipped with a Command Console along with the B2000 Command Computer. To free up the weight required to fit this device, the 10-Z-DC reduces its LRM10 to a LRM5. The well supplied AC20 makes the Cyclops deadly at close range.  With the addition of the Command Console features this model is prized, but is extremely an extremely rare sight.",
+		"Details": "The preferred command 'Mech of the Capellan Confederation, the CP-10-Z-DC is equipped with a Command Console instead of a B2000 Command Computer. To free up the weight required to fit this device, the 10-Z-DC reduces its LRM10 to a LRM5. The well supplied AC20 makes the Cyclops deadly at close range.  With the addition of the Command Console features this model is prized, but is extremely an extremely rare sight.",
 		"Icon": "uixTxrIcon_cyclops"
 	},
 	"MovementCapDefID": "movedef_cyclops_CP-10-Z",

--- a/Flashpoint Unit Module/mech/mechdef_cyclops_CP-10-Z-DC.json
+++ b/Flashpoint Unit Module/mech/mechdef_cyclops_CP-10-Z-DC.json
@@ -42,7 +42,7 @@
 		"UIName": "Cyclops CP-10-Z-DC",
 		"Id": "mechdef_cyclops_CP-10-Z-DC",
 		"Name": "Cyclops",
-		"Details": "The preferred command 'Mech of the Capellan Confederation, the CP-10-Z-DC equipped with a Command Console. To free up the weight required to fit this device, the 10-Z-DC reduces its LRM10 to a LRM5. The well supplied AC20 makes the Cyclops deadly at close range.  With the addition of the Command Console features this model is prized, but is extremely an extremely rare sight.",
+		"Details": "The preferred command 'Mech of the Capellan Confederation, the CP-10-Z-DC is equipped with a Command Console instead of a B2000 Command Computer. To free up the weight required to fit this device, the 10-Z-DC reduces its LRM10 to a LRM5. The well supplied AC20 makes the Cyclops deadly at close range.  With the addition of the Command Console features this model is prized, but is extremely an extremely rare sight.",
 		"Icon": "uixTxrIcon_cyclops"
 	},
 	"simGameMechPartCost": 1080000,

--- a/MechengineerGear/data/vanilla/targetTrackingSystem/Gear_TargetingTrackingSystem_Hartford_F3000.json
+++ b/MechengineerGear/data/vanilla/targetTrackingSystem/Gear_TargetingTrackingSystem_Hartford_F3000.json
@@ -16,7 +16,7 @@
 		},
 		"BonusDescriptions": {
 			"Bonuses": [
-				"EvasionIgnore: +1",
+				"MissileEvasionIgnore: +1",
 				"IsSensorsB"
 			]
 		},

--- a/MechengineerGear/data/vanilla/targetTrackingSystem/Gear_TargetingTrackingSystem_Hartford_S2000.json
+++ b/MechengineerGear/data/vanilla/targetTrackingSystem/Gear_TargetingTrackingSystem_Hartford_S2000.json
@@ -16,7 +16,7 @@
 		},
 		"BonusDescriptions": {
 			"Bonuses": [
-				"EvasionIgnore: +2",
+				"MissileEvasionIgnore: +2",
 				"IsSensorsB"
 			]
 		},

--- a/MechengineerGear/data/vanilla/targetTrackingSystem/Gear_TargetingTrackingSystem_Kallon_A-C-P150+.json
+++ b/MechengineerGear/data/vanilla/targetTrackingSystem/Gear_TargetingTrackingSystem_Kallon_A-C-P150+.json
@@ -13,7 +13,7 @@
 		},
 		"BonusDescriptions": {
 			"Bonuses": [
-				"EvasionIgnore: +1",
+				"BallisticEvasionIgnore: +1",
 				"IsSensorsB"
 			]
 		},

--- a/MechengineerGear/data/vanilla/targetTrackingSystem/Gear_TargetingTrackingSystem_Kallon_Lock-On.json
+++ b/MechengineerGear/data/vanilla/targetTrackingSystem/Gear_TargetingTrackingSystem_Kallon_Lock-On.json
@@ -13,7 +13,7 @@
 		},
 		"BonusDescriptions": {
 			"Bonuses": [
-				"EvasionIgnore: +2",
+				"BallisticEvasionIgnore: +2",
 				"IsSensorsB"
 			]
 		},

--- a/MechengineerGear/data/vanilla/targetTrackingSystem/Gear_TargetingTrackingSystem_RCA_InstaTrac-X.json
+++ b/MechengineerGear/data/vanilla/targetTrackingSystem/Gear_TargetingTrackingSystem_RCA_InstaTrac-X.json
@@ -13,7 +13,7 @@
 		},
 		"BonusDescriptions": {
 			"Bonuses": [
-				"EvasionIgnore: +1",
+				"EnergyEvasionIgnore: +1",
 				"IsSensorsB"
 			]
 		},

--- a/MechengineerGear/data/vanilla/targetTrackingSystem/Gear_TargetingTrackingSystem_RCA_InstaTrac-XII.json
+++ b/MechengineerGear/data/vanilla/targetTrackingSystem/Gear_TargetingTrackingSystem_RCA_InstaTrac-XII.json
@@ -13,7 +13,7 @@
 		},
 		"BonusDescriptions": {
 			"Bonuses": [
-				"EvasionIgnore: +2",
+				"EnergyEvasionIgnore: +2",
 				"IsSensorsB"
 			]
 		},


### PR DESCRIPTION
Added in some BonusDescriptions for specific TTS evasion ignore and adjusted the corresponding TTS Evasion modules.

Also amended CP-10-Z-DC description to remove mention of the Battle Computer which it doesn't have.