### PR TITLE
ravagaer affinity fix

### DIFF
--- a/MechAffinity/settings.json
+++ b/MechAffinity/settings.json
@@ -1656,7 +1656,7 @@
 				"Kanazuchi_8",
 				"BA Marauder_9",
 				"Phalanx_6",
-				"BA Ravager_9",
+				"BA Ravager_10",
 				"Grenadier_8"
 			],
 			"affinityLevels": [


### PR DESCRIPTION
updated tonnage, should now show up as having armor block

Please reach out to the team via discord (https://discord.com/invite/g5nCYAV) before opening a PR. We appreciate community input, but prefer to get to know you first.
