### PR TITLE
CF fix

### DIFF
--- a/CustomFilters/mod.json
+++ b/CustomFilters/mod.json
@@ -272,7 +272,7 @@
 						"Filter": {
 							"Categories": [
 								"a/a/g/gauss",
-								"w/a/g/hag",
+								"a/a/g/hag",
 								"a/a/g/massdriver"
 							],
 							"NotCategories": [


### PR DESCRIPTION
preemptive fix, ammo tag first letter changed to a so it wont sort weapon and ammo to both locations

Please reach out to the team via discord (https://discord.com/invite/g5nCYAV) before opening a PR. We appreciate community input, but prefer to get to know you first.
