### PR TITLE
endosteel no salvage fix

### DIFF
--- a/MechengineerGear/data/basic/internals/emod_structureslots_endosteel.json
+++ b/MechengineerGear/data/basic/internals/emod_structureslots_endosteel.json
@@ -27,6 +27,13 @@
 				"TechCost": "[[Chassis.Tonnage]] / 4",
 				"CBillCost": "1000 * [[Chassis.Tonnage]] * [[Chassis.Tonnage]] / 20"
 			}
+		},
+		"Flags": {
+			"flags": [
+				"ignore_damage",
+				"not_broken",
+				"no_salvage"
+			]
 		}
 	},
 	"Description": {


### PR DESCRIPTION
should stop endosteel from showing up in salvage anyways

Please reach out to the team via discord (https://discord.com/invite/g5nCYAV) before opening a PR. We appreciate community input, but prefer to get to know you first.
