### PR TITLE
CS-1 armor fix

### DIFF
--- a/BT Advanced Clan Mechs/mech/mechdef_fox_CS-1.json
+++ b/BT Advanced Clan Mechs/mech/mechdef_fox_CS-1.json
@@ -110,7 +110,7 @@
 	"inventory": [
 		{
 			"MountedLocation": "CenterTorso",
-			"ComponentDefID": "emod_armorslots_standard",
+			"ComponentDefID": "emod_armorslots_clstandard",
 			"ComponentDefType": "Upgrade",
 			"HardpointSlot": -1,
 			"DamageLevel": "Functional",


### PR DESCRIPTION
so the armor is upgradeable...it wont allow the upgrade if it a clan mech has IS standard armor

Please reach out to the team via discord (https://discord.com/invite/g5nCYAV) before opening a PR. We appreciate community input, but prefer to get to know you first.
