### PR TITLE
kitfox C fix

### DIFF
--- a/BT Advanced Clan Mechs/chassis/chassisdef_kitfox_C.json
+++ b/BT Advanced Clan Mechs/chassis/chassisdef_kitfox_C.json
@@ -248,6 +248,10 @@
 				{
 					"WeaponMountID": "AntiPersonnel",
 					"Omni": false
+				},
+				{
+					"WeaponMountID": "AntiPersonnel",
+					"Omni": false
 				}
 			],
 			"Tonnage": 0,


### PR DESCRIPTION
added missing right arm hardpoint so it can fit its stock loadout.  should they be omni hardpoints instead of AP?

Please reach out to the team via discord (https://discord.com/invite/g5nCYAV) before opening a PR. We appreciate community input, but prefer to get to know you first.
