### PR TITLE
tank cargo crate loot fix

### DIFF
--- a/BT Advanced Clan Mechs/mech/mechdef_widowmaker_DW-BW.json
+++ b/BT Advanced Clan Mechs/mech/mechdef_widowmaker_DW-BW.json
@@ -5,7 +5,7 @@
 			"unit_mechtool",
 			"ai_melee_low",
 			"ai_dfa_low",
-			"NOSALVAGEMECH",
+			"NOSALVAGE",
 			"BLACKLISTED"
 		],
 		"tagSetSourceFile": ""

--- a/BT Advanced Mechs/chassis/chassisdef_urbanmech_UM-TD.json
+++ b/BT Advanced Mechs/chassis/chassisdef_urbanmech_UM-TD.json
@@ -221,7 +221,7 @@
 	"VariantName": "UM-TD",
 	"ChassisTags": {
 		"items": [
-			"NOSALVAGEMECH",
+			"NOSALVAGE",
 			"LightMech"
 		],
 		"tagSetSourceFile": ""

--- a/BT Advanced Mechs/mech/mechdef_charger_CGR-FB.json
+++ b/BT Advanced Mechs/mech/mechdef_charger_CGR-FB.json
@@ -8,7 +8,7 @@
 			"unit_role_scout",
 			"unit_fallback",
 			"unit_legal",
-			"NOSALVAGEMECH"
+			"NOSALVAGE"
 		],
 		"tagSetSourceFile": ""
 	},

--- a/BT Advanced Mechs/mech/mechdef_crabrauder_CRB-MAD-1X.json
+++ b/BT Advanced Mechs/mech/mechdef_crabrauder_CRB-MAD-1X.json
@@ -8,7 +8,7 @@
 			"unit_release",
 			"unit_rarity_1",
 			"Circinus",
-			"NOSALVAGEMECH",
+			"NOSALVAGE",
 			"unit_legal"
 		],
 		"tagSetSourceFile": ""

--- a/BT Advanced Mechs/mech/mechdef_marauderiibountyhunter_MAD-II-BH.json
+++ b/BT Advanced Mechs/mech/mechdef_marauderiibountyhunter_MAD-II-BH.json
@@ -3,7 +3,7 @@
 		"items": [
 			"unit_release",
 			"unit_mechtool",
-			"NOSALVAGEMECH",
+			"NOSALVAGE",
 			"BLACKLISTED"
 		],
 		"tagSetSourceFile": ""

--- a/BT Advanced Mechs/mech/mechdef_shortyrifleman_RFL-SH.json
+++ b/BT Advanced Mechs/mech/mechdef_shortyrifleman_RFL-SH.json
@@ -6,7 +6,7 @@
 			"unit_release",
 			"unit_rarity_1",
 			"SnordsIrregulars",
-			"NOSALVAGEMECH",
+			"NOSALVAGE",
 			"unit_lance_support",
 			"unit_role_sniper",
 			"unit_legal"

--- a/BT Advanced Mechs/mech/mechdef_urbanmech_UM-TD.json
+++ b/BT Advanced Mechs/mech/mechdef_urbanmech_UM-TD.json
@@ -2,7 +2,7 @@
 	"MechTags": {
 		"items": [
 			"unit_bta_training_mech",
-			"NOSALVAGEMECH"
+			"NOSALVAGE"
 		],
 		"tagSetSourceFile": ""
 	},

--- a/BT Advanced Unique Mechs/mech/mechdef_cataphract_CTF-FR.json
+++ b/BT Advanced Unique Mechs/mech/mechdef_cataphract_CTF-FR.json
@@ -8,7 +8,7 @@
 			"unit_release",
 			"unit_bracket_med",
 			"unit_generic",
-			"NOSALVAGEMECH",
+			"NOSALVAGE",
 			"unit_legal"
 		],
 		"tagSetSourceFile": ""

--- a/BT Advanced Unique Mechs/mech/mechdef_corsair_COR-TB.json
+++ b/BT Advanced Unique Mechs/mech/mechdef_corsair_COR-TB.json
@@ -6,7 +6,7 @@
 			"unit_lance_assassin",
 			"unit_role_sniper",
 			"unit_release",
-			"NOSALVAGEMECH",
+			"NOSALVAGE",
 			"unit_legal"
 		],
 		"tagSetSourceFile": ""

--- a/BT Advanced Unique Mechs/mech/mechdef_hunchback_HBK-IIC-TR.json
+++ b/BT Advanced Unique Mechs/mech/mechdef_hunchback_HBK-IIC-TR.json
@@ -7,7 +7,7 @@
 			"unit_lance_tank",
 			"unit_role_sniper",
 			"unit_bracket_med",
-			"NOSALVAGEMECH",
+			"NOSALVAGE",
 			"unit_legal"
 		],
 		"tagSetSourceFile": ""

--- a/BT Advanced Unique Mechs/mech/mechdef_kingcrab_KGC-BD.json
+++ b/BT Advanced Unique Mechs/mech/mechdef_kingcrab_KGC-BD.json
@@ -7,7 +7,7 @@
 			"unit_lance_tank",
 			"unit_role_brawler",
 			"unit_release",
-			"NOSALVAGEMECH",
+			"NOSALVAGE",
 			"unit_legal"
 		],
 		"tagSetSourceFile": ""

--- a/BT Advanced Unique Mechs/mech/mechdef_kitfox_KFX-BW.json
+++ b/BT Advanced Unique Mechs/mech/mechdef_kitfox_KFX-BW.json
@@ -7,7 +7,7 @@
 			"unit_lance_support",
 			"unit_role_scout",
 			"unit_advanced",
-			"NOSALVAGEMECH",
+			"NOSALVAGE",
 			"unit_legal",
 			"unit_bracket_low"
 		],

--- a/BT Advanced Unique Mechs/mech/mechdef_marauder_MAD-3TL.json
+++ b/BT Advanced Unique Mechs/mech/mechdef_marauder_MAD-3TL.json
@@ -6,7 +6,7 @@
 			"unit_heavy",
 			"unit_lance_tank",
 			"unit_role_sniper",
-			"NOSALVAGEMECH"
+			"NOSALVAGE"
 		],
 		"tagSetSourceFile": ""
 	},

--- a/BT Advanced Unique Mechs/mech/mechdef_timberwolf_TW-RV.json
+++ b/BT Advanced Unique Mechs/mech/mechdef_timberwolf_TW-RV.json
@@ -8,7 +8,7 @@
 			"unit_lance_support",
 			"unit_role_sniper",
 			"unit_advanced",
-			"NOSALVAGEMECH",
+			"NOSALVAGE",
 			"unit_legal",
 			"unit_indirectFire",
 			"unit_bracket_high"

--- a/BT Advanced Unique Mechs/mech/mechdef_valkyrieii_VLK-II-SH.json
+++ b/BT Advanced Unique Mechs/mech/mechdef_valkyrieii_VLK-II-SH.json
@@ -7,7 +7,7 @@
 			"unit_lance_vanguard",
 			"unit_role_flanker",
 			"unit_jumpOK",
-			"NOSALVAGEMECH",
+			"NOSALVAGE",
 			"unit_legal"
 		],
 		"tagSetSourceFile": ""

--- a/CustomSalvage/mod.json
+++ b/CustomSalvage/mod.json
@@ -33,7 +33,7 @@
 		"SalvageTurretsComponentChance": 0.33,
 		"UpgradeSalvage": false,
 		"AllowDropBlackListed": false,
-		"NoSalvageMechTag": "NOSALVAGEMECH",
+		"NoSalvageMechTag": "NOSALVAGE",
 		"BGColors": [
 			{
 				"Tag": "unit_assault",
@@ -109,7 +109,7 @@
 		"FullUnitUsedAmountOfLootableComponents": true,
 		"FullUnitStructurePersentage": 0.45,
 		"SquadDisassembleComponents": true,
-		"VehicleDisassembleComponents": false,
+		"VehicleDisassembleComponents": true,
 		"VehicleAlwaysDisassembled": true
 	},
 	"Manifest": [

--- a/Flashpoint DLC Flashpoints/chassis/chassisdef_atlas_AS7-D-HK.json
+++ b/Flashpoint DLC Flashpoints/chassis/chassisdef_atlas_AS7-D-HK.json
@@ -250,7 +250,7 @@
 	"ChassisTags": {
 		"items": [
 			"RoyalMech",
-			"NOSALVAGEMECH",
+			"NOSALVAGE",
 			"AssaultMech"
 		],
 		"tagSetSourceFile": ""

--- a/Flashpoint DLC Flashpoints/chassis/chassisdef_kingcrab_KGC-000v.json
+++ b/Flashpoint DLC Flashpoints/chassis/chassisdef_kingcrab_KGC-000v.json
@@ -232,7 +232,7 @@
 	"VariantName": "KGC-000v",
 	"ChassisTags": {
 		"items": [
-			"NOSALVAGEMECH",
+			"NOSALVAGE",
 			"RoyalMech",
 			"ArmLimitLowerRight",
 			"ArmLimitLowerLeft",

--- a/Flashpoint DLC Flashpoints/mech/mechdef_Catapult_fp_justinAllard.json
+++ b/Flashpoint DLC Flashpoints/mech/mechdef_Catapult_fp_justinAllard.json
@@ -3,7 +3,7 @@
 	"MechTags": {
 		"items": [
 			"unit_flashpoint",
-			"NOSALVAGEMECH",
+			"NOSALVAGE",
 			"BLACKLISTED"
 		],
 		"tagSetSourceFile": ""

--- a/Flashpoint DLC Flashpoints/mech/mechdef_Centurion_fp_justinAllard.json
+++ b/Flashpoint DLC Flashpoints/mech/mechdef_Centurion_fp_justinAllard.json
@@ -3,7 +3,7 @@
 	"MechTags": {
 		"items": [
 			"unit_flashpoint",
-			"NOSALVAGEMECH",
+			"NOSALVAGE",
 			"BLACKLISTED"
 		],
 		"tagSetSourceFile": ""

--- a/Flashpoint DLC Flashpoints/mech/mechdef_Dragon_fp_justinAllard.json
+++ b/Flashpoint DLC Flashpoints/mech/mechdef_Dragon_fp_justinAllard.json
@@ -3,7 +3,7 @@
 	"MechTags": {
 		"items": [
 			"unit_flashpoint",
-			"NOSALVAGEMECH",
+			"NOSALVAGE",
 			"BLACKLISTED"
 		],
 		"tagSetSourceFile": ""

--- a/Flashpoint DLC Flashpoints/mech/mechdef_Griffin_fp_justinAllard.json
+++ b/Flashpoint DLC Flashpoints/mech/mechdef_Griffin_fp_justinAllard.json
@@ -3,7 +3,7 @@
 	"MechTags": {
 		"items": [
 			"unit_flashpoint",
-			"NOSALVAGEMECH",
+			"NOSALVAGE",
 			"BLACKLISTED"
 		],
 		"tagSetSourceFile": ""

--- a/Flashpoint DLC Flashpoints/mech/mechdef_atlas_AS7-D-HK.json
+++ b/Flashpoint DLC Flashpoints/mech/mechdef_atlas_AS7-D-HK.json
@@ -2,7 +2,7 @@
 	"MechTags": {
 		"items": [
 			"unit_flashpoint",
-			"NOSALVAGEMECH",
+			"NOSALVAGE",
 			"unit_legal"
 		],
 		"tagSetSourceFile": ""

--- a/Flashpoint DLC Flashpoints/mech/mechdef_fp_morganKell_stalker_STK-3F.json
+++ b/Flashpoint DLC Flashpoints/mech/mechdef_fp_morganKell_stalker_STK-3F.json
@@ -2,7 +2,7 @@
 	"MechTags": {
 		"items": [
 			"unit_flashpoint",
-			"NOSALVAGEMECH",
+			"NOSALVAGE",
 			"BLACKLISTED"
 		],
 		"tagSetSourceFile": ""

--- a/Flashpoint DLC Flashpoints/mech/mechdef_jagermech_JM6-S_fp_headhunting.json
+++ b/Flashpoint DLC Flashpoints/mech/mechdef_jagermech_JM6-S_fp_headhunting.json
@@ -2,7 +2,7 @@
 	"MechTags": {
 		"items": [
 			"unit_flashpoint",
-			"NOSALVAGEMECH",
+			"NOSALVAGE",
 			"BLACKLISTED"
 		],
 		"tagSetSourceFile": ""

--- a/Flashpoint DLC Flashpoints/mech/mechdef_kingcrab_KGC-000v.json
+++ b/Flashpoint DLC Flashpoints/mech/mechdef_kingcrab_KGC-000v.json
@@ -2,7 +2,7 @@
 	"MechTags": {
 		"items": [
 			"unit_flashpoint",
-			"NOSALVAGEMECH",
+			"NOSALVAGE",
 			"BLACKLISTED",
 			"unit_legal"
 		],

--- a/Flashpoint DLC Flashpoints/mech/mechdef_thunderbolt_TDR-5SE_fp_headhunting.json
+++ b/Flashpoint DLC Flashpoints/mech/mechdef_thunderbolt_TDR-5SE_fp_headhunting.json
@@ -2,7 +2,7 @@
 	"MechTags": {
 		"items": [
 			"unit_flashpoint",
-			"NOSALVAGEMECH",
+			"NOSALVAGE",
 			"BLACKLISTED"
 		],
 		"tagSetSourceFile": ""

--- a/Heavy Metal Flashpoint Module/mech/mechdef_battlemaster_BLR-1G_fp_morganKell.json
+++ b/Heavy Metal Flashpoint Module/mech/mechdef_battlemaster_BLR-1G_fp_morganKell.json
@@ -2,7 +2,7 @@
 	"MechTags": {
 		"items": [
 			"unit_flashpoint",
-			"NOSALVAGEMECH",
+			"NOSALVAGE",
 			"BLACKLISTED"
 		],
 		"tagSetSourceFile": ""

--- a/Heavy Metal Flashpoint Module/mech/mechdef_enforcer_ENF-4R_fp_morganKell.json
+++ b/Heavy Metal Flashpoint Module/mech/mechdef_enforcer_ENF-4R_fp_morganKell.json
@@ -2,7 +2,7 @@
 	"MechTags": {
 		"items": [
 			"unit_flashpoint",
-			"NOSALVAGEMECH",
+			"NOSALVAGE",
 			"BLACKLISTED"
 		],
 		"tagSetSourceFile": ""

--- a/Heavy Metal Flashpoint Module/mech/mechdef_jenner_JR7-D_fp_morganKell.json
+++ b/Heavy Metal Flashpoint Module/mech/mechdef_jenner_JR7-D_fp_morganKell.json
@@ -2,7 +2,7 @@
 	"MechTags": {
 		"items": [
 			"unit_flashpoint",
-			"NOSALVAGEMECH",
+			"NOSALVAGE",
 			"BLACKLISTED"
 		],
 		"tagSetSourceFile": ""

--- a/Heavy Metal Flashpoint Module/mech/mechdef_orion_ON1-K_fp_morganKell.json
+++ b/Heavy Metal Flashpoint Module/mech/mechdef_orion_ON1-K_fp_morganKell.json
@@ -2,7 +2,7 @@
 	"MechTags": {
 		"items": [
 			"unit_flashpoint",
-			"NOSALVAGEMECH",
+			"NOSALVAGE",
 			"BLACKLISTED"
 		],
 		"tagSetSourceFile": ""

--- a/Heavy Metal Flashpoint Module/mech/mechdef_stalker_STK-BM.json
+++ b/Heavy Metal Flashpoint Module/mech/mechdef_stalker_STK-BM.json
@@ -20,7 +20,7 @@
 			"ai_surrounded_normal",
 			"unit_legal",
 			"unit_flashpoint",
-			"NOSALVAGEMECH",
+			"NOSALVAGE",
 			"BLACKLISTED"
 		],
 		"tagSetSourceFile": ""

--- a/Heavy Metal Unit Module/chassis/chassisdef_annihilator_ANH-JH.json
+++ b/Heavy Metal Unit Module/chassis/chassisdef_annihilator_ANH-JH.json
@@ -217,7 +217,7 @@
 	"VariantName": "ANH-JH",
 	"ChassisTags": {
 		"items": [
-			"NOSALVAGEMECH",
+			"NOSALVAGE",
 			"ArmLimitLowerRight",
 			"ArmLimitLowerLeft",
 			"AssaultMech",

--- a/Heavy Metal Unit Module/chassis/chassisdef_archer_ARC-LS.json
+++ b/Heavy Metal Unit Module/chassis/chassisdef_archer_ARC-LS.json
@@ -201,7 +201,7 @@
 	"VariantName": "ARC-LS",
 	"ChassisTags": {
 		"items": [
-			"NOSALVAGEMECH",
+			"NOSALVAGE",
 			"HeavyMech"
 		],
 		"tagSetSourceFile": ""

--- a/Heavy Metal Unit Module/chassis/chassisdef_archer_ARC-XO.json
+++ b/Heavy Metal Unit Module/chassis/chassisdef_archer_ARC-XO.json
@@ -201,7 +201,7 @@
 	"VariantName": "ARC-XO",
 	"ChassisTags": {
 		"items": [
-			"NOSALVAGEMECH",
+			"NOSALVAGE",
 			"HeavyMech"
 		],
 		"tagSetSourceFile": ""

--- a/Heavy Metal Unit Module/chassis/chassisdef_atlas_AS7-GG.json
+++ b/Heavy Metal Unit Module/chassis/chassisdef_atlas_AS7-GG.json
@@ -212,7 +212,7 @@
 	"VariantName": "AS7-GG",
 	"ChassisTags": {
 		"items": [
-			"NOSALVAGEMECH",
+			"NOSALVAGE",
 			"AssaultMech"
 		],
 		"tagSetSourceFile": ""

--- a/Heavy Metal Unit Module/chassis/chassisdef_marauder_MAD-BH.json
+++ b/Heavy Metal Unit Module/chassis/chassisdef_marauder_MAD-BH.json
@@ -211,7 +211,7 @@
 	"VariantName": "MAD-BH",
 	"ChassisTags": {
 		"items": [
-			"NOSALVAGEMECH",
+			"NOSALVAGE",
 			"ArmLimitLowerRight",
 			"ArmLimitLowerLeft",
 			"HeavyMech"

--- a/Heavy Metal Unit Module/chassis/chassisdef_marauder_MAD-CM.json
+++ b/Heavy Metal Unit Module/chassis/chassisdef_marauder_MAD-CM.json
@@ -211,7 +211,7 @@
 	"VariantName": "MAD-CM",
 	"ChassisTags": {
 		"items": [
-			"NOSALVAGEMECH",
+			"NOSALVAGE",
 			"ArmLimitLowerRight",
 			"ArmLimitLowerLeft",
 			"HeavyMech"

--- a/Heavy Metal Unit Module/chassis/chassisdef_rifleman_RFL-RIP.json
+++ b/Heavy Metal Unit Module/chassis/chassisdef_rifleman_RFL-RIP.json
@@ -207,7 +207,7 @@
 	"VariantName": "RFL-RIP",
 	"ChassisTags": {
 		"items": [
-			"NOSALVAGEMECH",
+			"NOSALVAGE",
 			"ArmLimitUpperRight",
 			"ArmLimitUpperLeft",
 			"HeavyMech"

--- a/Heavy Metal Unit Module/chassis/chassisdef_warhammer_WHM-BW.json
+++ b/Heavy Metal Unit Module/chassis/chassisdef_warhammer_WHM-BW.json
@@ -208,7 +208,7 @@
 	"VariantName": "WHM-BW",
 	"ChassisTags": {
 		"items": [
-			"NOSALVAGEMECH",
+			"NOSALVAGE",
 			"HeroMech",
 			"ArmLimitLowerRight",
 			"ArmLimitLowerLeft",

--- a/Heavy Metal Unit Module/mech/mechdef_marauder_MAD-BH.json
+++ b/Heavy Metal Unit Module/mech/mechdef_marauder_MAD-BH.json
@@ -462,7 +462,7 @@
 			"unit_hot",
 			"unit_speed_low",
 			"unit_common",
-			"NOSALVAGEMECH",
+			"NOSALVAGE",
 			"BLACKLISTED"
 		],
 		"tagSetSourceFile": ""

--- a/Heavy Metal Unit Module/mech/mechdef_warhammer_WHM-BW.json
+++ b/Heavy Metal Unit Module/mech/mechdef_warhammer_WHM-BW.json
@@ -6,7 +6,7 @@
 			"unit_role_brawler",
 			"unit_range_medium",
 			"unit_speed_low",
-			"NOSALVAGEMECH",
+			"NOSALVAGE",
 			"unit_gladiator",
 			"ai_heat_normal",
 			"ai_dfa_normal",


### PR DESCRIPTION
found the issue and changed it, changed the NOSALVAGEMECH back to the NOSALVAGE tag

Please reach out to the team via discord (https://discord.com/invite/g5nCYAV) before opening a PR. We appreciate community input, but prefer to get to know you first.
