### PR TITLE
fix

### DIFF
--- a/BT Advanced Core/settings/tagRestrictions/TagRestrictions_MechEngineer.json
+++ b/BT Advanced Core/settings/tagRestrictions/TagRestrictions_MechEngineer.json
@@ -393,7 +393,8 @@
 			"Tag": "Handhold",
 			"IncompatibleTags": [
 				"OmniGyro",
-				"Avionics"
+				"Avionics",
+				"ProtoMech"
 			]
 		},
 		{


### PR DESCRIPTION
to stop BA handholds from being put on the BA themselves

Please reach out to the team via discord (https://discord.com/invite/g5nCYAV) before opening a PR. We appreciate community input, but prefer to get to know you first.
