### PR TITLE
gets apgauss back in the ammo tabs

### DIFF
--- a/CustomFilters/BTATabs.json
+++ b/CustomFilters/BTATabs.json
@@ -347,7 +347,8 @@
 						"a/a/g/hag",
 						"a/a/g/massdriver",
 						"a/a/g/sbgauss",
-						"a/a/g/railgun"
+						"a/a/g/railgun",
+						"a/a/g/magshot"
 					],
 					"NotCategories": [
 						"notused"

--- a/CustomFilters/BTATabs.json
+++ b/CustomFilters/BTATabs.json
@@ -347,8 +347,7 @@
 						"a/a/g/hag",
 						"a/a/g/massdriver",
 						"a/a/g/sbgauss",
-						"a/a/g/railgun",
-						"a/a/g/magshot"
+						"a/a/g/railgun"
 					],
 					"NotCategories": [
 						"notused"
@@ -471,6 +470,7 @@
 					"Categories": [
 						"a/s/a/mg",
 						"a/s/a/magshot",
+						"a/a/g/magshot",
 						"a/a/o/grenade",
 						"a/e/p/fluidgun"
 					],


### PR DESCRIPTION
so the ammo can be found and used in the mechbay, might need to be updated to not be magshot

Please reach out to the team via discord (https://discord.com/invite/g5nCYAV) before opening a PR. We appreciate community input, but prefer to get to know you first.
