### PR TITLE
AssetDenial fix

### DIFF
--- a/BT Advanced Contracts/contract/ambushconvoy/5/AmbushConvoy_AssetDenial_NEW.json
+++ b/BT Advanced Contracts/contract/ambushconvoy/5/AmbushConvoy_AssetDenial_NEW.json
@@ -1119,12 +1119,14 @@
 				"lanceDefId": "Tagged",
 				"lanceTagSet": {
 					"items": [
-						"lance_type_vehicle"
+						"lance_type_notallvehicles"
 					],
 					"tagSetSourceFile": "tags/LanceTags"
 				},
 				"lanceExcludedTagSet": {
 					"items": [
+						"lance_type_turret",
+						"lance_type_convoy",
 						"lance_type_gladiator"
 					],
 					"tagSetSourceFile": "tags/LanceTags"


### PR DESCRIPTION
should stop the convoy trucks from appearing in the OpFor ambushing lance

Please reach out to the team via discord (https://discord.com/invite/g5nCYAV) before opening a PR. We appreciate community input, but prefer to get to know you first.
