### PR TITLE
component destruction crits

### DIFF
--- a/MechEngineer/Settings.json
+++ b/MechEngineer/Settings.json
@@ -224,7 +224,7 @@
 	},
 	"CriticalEffects": {
 		"Enabled": true,
-		"ShowComponentFloatie": false,
+		"ShowComponentFloatie": true,
 		"DefaultMaxCritsPerSlots": 0,
 		"DefaultMaxCritsPerSlotsDescription": "How many critical hits a component by default can take for each occupied slot. For CBT use 0, for Expanded Critical Damage behavior use 0.5. Custom CriticalEffects overwrite this behavior.",
 		"DefaultMaxCritsComponentTypes": [


### PR DESCRIPTION
turned back on to have them show up again

Please reach out to the team via discord (https://discord.com/invite/g5nCYAV) before opening a PR. We appreciate community input, but prefer to get to know you first.
