### PR TITLE
MissionControl tweak

### DIFF
--- a/MissionControl/settings.json
+++ b/MissionControl/settings.json
@@ -175,7 +175,7 @@
 			},
 			{
 				"MapId": "mapGeneral_splitRange_iGlc",
-				"IncreaseBoundarySizeByPercentage": 0.5
+				"IncreaseBoundarySizeByPercentage": 0.6
 			},
 			{
 				"MapId": "mapGeneral_centralPond_uTech",


### PR DESCRIPTION
increased mission area for mapGeneral_splitRange_iGlc again...apparently still not enough room for spawns with the giant mountain in the middle of the map

Please reach out to the team via discord (https://discord.com/invite/g5nCYAV) before opening a PR. We appreciate community input, but prefer to get to know you first.
